### PR TITLE
Update daisydisk version

### DIFF
--- a/overlays/daisydisk.nix
+++ b/overlays/daisydisk.nix
@@ -1,0 +1,10 @@
+self: super: {
+  daisydisk = super.daisydisk.overrideAttrs (old: {
+    version = "4.32";
+    src = super.fetchzip {
+      url = "https://daisydiskapp.com/download/DaisyDisk.zip";
+      hash = "sha256-HRW851l3zCq43WmLkElvVlIEmfCsCUMFw/LL2cPa2Xk=";
+      stripRoot = false;
+    };
+  });
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -2,4 +2,7 @@
 [
   # Custom packages defined in this repository
   (import ./custom-packages.nix)
+
+  # Fix Daisydisk ahead of upstream
+  (import ./daisydisk.nix)
 ]


### PR DESCRIPTION
Apply an overlay to use the updated version of `daisydisk` upstream, since there seems to be no easy way to target the specific version.