### PR TITLE
feat(home): add nix-index-database flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,6 +290,26 @@
         "type": "github"
       }
     },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772341813,
+        "narHash": "sha256-/PQ0ubBCMj/MVCWEI/XMStn55a8dIKsvztj4ZVLvUrQ=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "a2051ff239ce2e8a0148fa7a152903d9a78e854f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
     "nixos-hardware": {
       "locked": {
         "lastModified": 1771969195,
@@ -350,6 +370,7 @@
         "llm-profile": "llm-profile",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
+        "nix-index-database": "nix-index-database",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
         "nixpkgs-stable": "nixpkgs-stable",

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,10 @@
       url = "github:cachix/git-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nix-index-database = {
+      url = "github:nix-community/nix-index-database";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nixos-hardware.url = "github:NixOS/nixos-hardware";
 
     # Linux

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -9,6 +9,7 @@ inputs @ {
   homebrew-core,
   homebrew-cask,
   llm-profile,
+  nix-index-database,
   zx-dev,
   disko,
   golink,
@@ -35,6 +36,7 @@ inputs @ {
     home-manager.users.${username} = {...}: {
       imports =
         [
+          nix-index-database.hmModules.nix-index
           agenix.homeManagerModules.default
           ./../modules/home
           ./../home

--- a/modules/home/utilities.nix
+++ b/modules/home/utilities.nix
@@ -85,9 +85,13 @@ in {
     })
 
     (mkIf cfg.nix.enable {
+      programs.nix-index = {
+        enable = true;
+      };
+      programs.nix-index-database.comma.enable = true;
+
       home.packages =
         [
-          pkgs.comma
           pkgs.manix
           pkgs.nix-du
           pkgs.nix-tree


### PR DESCRIPTION
Wire up the nix-index-database flake to provide the comma binary with a pre-built nix-index database. This replaces the manually-installed pkgs.comma with the module-managed version, improving performance and reducing build overhead by using a pre-built database.

All configuration follows the existing patterns in the codebase with proper input follows and home-manager module wiring across both NixOS and macOS hosts.