### PR TITLE
feat(glyph): tune transmission settings for RPC performance

### DIFF
--- a/hosts/glyph/services/torrents.nix
+++ b/hosts/glyph/services/torrents.nix
@@ -50,6 +50,11 @@
           --form-string "url_title=View torrents" \
           https://api.pushover.net/1/messages.json
       '';
+      cache-size-mb = 256;
+      download-queue-enabled = true;
+      download-queue-size = 5;
+      queue-stalled-enabled = true;
+      queue-stalled-minutes = 30;
       utp-enabled = false;
       watch-dir = "/mnt/torrents/watch";
       watch-dir-enabled = true;


### PR DESCRIPTION
## Summary
- Increase Transmission disk write cache from default 4MB to 256MB to reduce I/O contention blocking the single-threaded RPC event loop
- Enable download queue (max 5 active, 30min stall timeout) to limit concurrent disk I/O
- Addresses slow web UI load times (~9-17s) caused by 2000+ loaded torrents

## Context
Transmission 4.1.1 has a [confirmed performance regression](https://github.com/transmission/transmission/issues/8401) with large torrent counts. The root cause is synchronous disk I/O blocking the RPC thread ([#2462](https://github.com/transmission/transmission/issues/2462), targeted for 5.0). These settings reduce I/O pressure as a mitigation. If insufficient, next step is pinning to transmission 4.0.6.

## Test plan
- [ ] Deploy to glyph via `nh os switch`
- [ ] Verify `curl -w "%{time_total}\n" -o /dev/null -s http://localhost:9091` response time improves
- [ ] Confirm torrents.zx.dev loads in reasonable time from browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)