### PR TITLE
feat: downgrade stable pkgs, use transmission 4.0.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,16 +496,16 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1774388614,
-        "narHash": "sha256-tFwzTI0DdDzovdE9+Ras6CUss0yn8P9XV4Ja6RjA+nU=",
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1073dad219cb244572b74da2b20c7fe39cb3fa9e",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -494,7 +494,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable_2": {
+    "nixpkgs-stable-24-05": {
       "locked": {
         "lastModified": 1735563628,
         "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
@@ -506,6 +506,22 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable-25-11": {
+      "locked": {
+        "lastModified": 1774388614,
+        "narHash": "sha256-tFwzTI0DdDzovdE9+Ras6CUss0yn8P9XV4Ja6RjA+nU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1073dad219cb244572b74da2b20c7fe39cb3fa9e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -528,7 +544,8 @@
         "nix-index-database": "nix-index-database",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-stable": "nixpkgs-stable_2",
+        "nixpkgs-stable-24-05": "nixpkgs-stable-24-05",
+        "nixpkgs-stable-25-11": "nixpkgs-stable-25-11",
         "systems": "systems_2",
         "zx-dev": "zx-dev"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-24.05";
+    nixpkgs-stable-25-11.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs-stable-24-05.url = "github:nixos/nixpkgs/nixos-24.05";
 
     # General
     systems = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-24.05";
 
     # General
     systems = {

--- a/hosts/glyph/home.nix
+++ b/hosts/glyph/home.nix
@@ -2,7 +2,7 @@
   config,
   llm-profile,
   pkgs,
-  pkgs-stable,
+  pkgs-stable-25-11,
   ...
 }: {
   home.packages = [pkgs.mktorrent];
@@ -38,7 +38,7 @@
 
   programs.beets = {
     enable = true;
-    package = pkgs-stable.beets;
+    package = pkgs-stable-25-11.beets;
     settings = {
       directory = "/mnt/media/Music";
       import = {

--- a/hosts/glyph/services/torrents.nix
+++ b/hosts/glyph/services/torrents.nix
@@ -1,7 +1,7 @@
 {
   config,
   pkgs,
-  pkgs-stable,
+  pkgs-stable-24-05,
   ...
 }: {
   age.secrets.pushover-user-token = {
@@ -20,7 +20,7 @@
 
   services.transmission = {
     enable = true;
-    package = pkgs-stable.transmission_4;
+    package = pkgs-stable-24-05.transmission_4;
     settings = {
       download-dir = "/mnt/torrents/complete";
       incomplete-dir = "/mnt/torrents/incomplete";

--- a/hosts/glyph/services/torrents.nix
+++ b/hosts/glyph/services/torrents.nix
@@ -1,6 +1,7 @@
 {
   config,
   pkgs,
+  pkgs-stable,
   ...
 }: {
   age.secrets.pushover-user-token = {
@@ -19,7 +20,7 @@
 
   services.transmission = {
     enable = true;
-    package = pkgs.transmission_4;
+    package = pkgs-stable.transmission_4;
     settings = {
       download-dir = "/mnt/torrents/complete";
       incomplete-dir = "/mnt/torrents/incomplete";

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -1,7 +1,8 @@
 inputs @ {
   self,
   nixpkgs,
-  nixpkgs-stable,
+  nixpkgs-stable-25-11,
+  nixpkgs-stable-24-05,
   agenix,
   home-manager,
   nix-darwin,
@@ -26,7 +27,8 @@ inputs @ {
     showBatteryStatus,
     lightweight ? false,
   }: let
-    pkgs-stable = import nixpkgs-stable {inherit system;};
+    pkgs-stable-25-11 = import nixpkgs-stable-25-11 {inherit system;};
+    pkgs-stable-24-05 = import nixpkgs-stable-24-05 {inherit system;};
     hostHomePath = ./../hosts/${hostname}/home.nix;
     hostHomeConfig =
       if builtins.pathExists hostHomePath
@@ -46,7 +48,7 @@ inputs @ {
         ++ nixpkgs.lib.optionals (hostHomeConfig != null) [hostHomeConfig];
     };
     home-manager.extraSpecialArgs = {
-      inherit hostname lightweight llm-profile pkgs-stable showBatteryStatus;
+      inherit hostname lightweight llm-profile pkgs-stable-25-11 pkgs-stable-24-05 showBatteryStatus;
     };
   };
 
@@ -60,7 +62,8 @@ inputs @ {
       inherit system;
       specialArgs = {
         inherit inputs keys username hostname;
-        pkgs-stable = import nixpkgs-stable {inherit system;};
+        pkgs-stable-25-11 = import nixpkgs-stable-25-11 {inherit system;};
+        pkgs-stable-24-05 = import nixpkgs-stable-24-05 {inherit system;};
       };
       modules = [
         {environment.systemPackages = [agenix.packages.${system}.default];}
@@ -94,7 +97,8 @@ inputs @ {
       inherit system;
       specialArgs = {
         inherit inputs self keys username hostname;
-        pkgs-stable = import nixpkgs-stable {inherit system;};
+        pkgs-stable-25-11 = import nixpkgs-stable-25-11 {inherit system;};
+        pkgs-stable-24-05 = import nixpkgs-stable-24-05 {inherit system;};
         nixDarwin = nix-darwin;
       };
       modules = [

--- a/modules/home/utilities.nix
+++ b/modules/home/utilities.nix
@@ -2,7 +2,6 @@
   config,
   lib,
   pkgs,
-  pkgs-stable,
   ...
 }: let
   inherit (lib) mkIf mkOption;
@@ -81,7 +80,7 @@ in {
 
       programs.yt-dlp = {
         enable = true;
-        package = pkgs-stable.yt-dlp;
+        package = pkgs.yt-dlp;
       };
     })
 


### PR DESCRIPTION
Effectively reverts #252. Newer version of transmission has performance regression (#325) and doesn't seem like it will be fixed anytime soon.