### PR TITLE
feat(spore): add WebFinger endpoint to Pocket ID nginx vhost

### DIFF
--- a/hosts/spore/services/web/default.nix
+++ b/hosts/spore/services/web/default.nix
@@ -36,11 +36,12 @@
         forceSSL = true;
         useACMEHost = "zx.dev";
         locations = {
-          "/.well-known/webfinger" = {
+          "= /.well-known/webfinger" = {
             extraConfig = ''
-              add_header Access-Control-Allow-Origin '*';
+              default_type application/jrd+json;
+              add_header Access-Control-Allow-Origin '*' always;
+              return 200 '{"subject":"$arg_resource","links":[{"rel":"http://openid.net/specs/connect/1.0/issuer","href":"https://id.zx.dev"}]}';
             '';
-            return = "301 https://pub.zx.dev$request_uri";
           };
           "/pgp".return = "302 https://keyoxide.org/hkp/413d1a0152bcb08d2e3ddacaf88c08579051ab48";
         };

--- a/modules/nixos/web/auth.nix
+++ b/modules/nixos/web/auth.nix
@@ -180,13 +180,6 @@ in {
         virtualHosts.${cfg.issuer.host} = {
           forceSSL = true;
           inherit (cfg.issuer) useACMEHost;
-          locations."= /.well-known/webfinger" = {
-            extraConfig = ''
-              default_type application/jrd+json;
-              add_header Access-Control-Allow-Origin '*' always;
-              return 200 '{"subject":"$arg_resource","links":[{"rel":"http://openid.net/specs/connect/1.0/issuer","href":"https://${cfg.issuer.host}"}]}';
-            '';
-          };
           locations."/" = {
             proxyPass = "http://127.0.0.1:1411";
             proxyWebsockets = true;

--- a/modules/nixos/web/auth.nix
+++ b/modules/nixos/web/auth.nix
@@ -180,6 +180,13 @@ in {
         virtualHosts.${cfg.issuer.host} = {
           forceSSL = true;
           inherit (cfg.issuer) useACMEHost;
+          locations."= /.well-known/webfinger" = {
+            extraConfig = ''
+              default_type application/jrd+json;
+              add_header Access-Control-Allow-Origin '*' always;
+              return 200 '{"subject":"$arg_resource","links":[{"rel":"http://openid.net/specs/connect/1.0/issuer","href":"https://${cfg.issuer.host}"}]}';
+            '';
+          };
           locations."/" = {
             proxyPass = "http://127.0.0.1:1411";
             proxyWebsockets = true;


### PR DESCRIPTION
## Summary

- Replaces the defunct Mastodon redirect at `zx.dev/.well-known/webfinger` with a direct OIDC issuer response
- Tailscale resolves WebFinger from the email domain (`zx.dev`), not the issuer host — this is the only change needed to support Tailscale custom OIDC with Pocket ID at `id.zx.dev`

## Test plan

- [ ] Deploy to spore: `nixos-rebuild switch --flake .#spore --target-host root@spore --build-host localhost`
- [ ] Verify: `curl --globoff 'https://zx.dev/.well-known/webfinger?resource=acct:corey@zx.dev'` returns JSON with `https://id.zx.dev` as the issuer href
- [ ] Confirm Tailscale custom OIDC login flow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)