### PR TITLE
fix(spore): stricter nix gc to prevent disk exhaustion

### DIFF
--- a/hosts/spore/default.nix
+++ b/hosts/spore/default.nix
@@ -50,5 +50,16 @@
     }
   ];
 
+  # Stricter GC due to limited disk space (30 GB)
+  nix.gc = {
+    dates = "daily";
+    options = "--delete-older-than 7d";
+  };
+
+  nix.settings = {
+    min-free = 1024 * 1024 * 1024; # 1 GB — trigger GC when free space drops below this
+    max-free = 5 * 1024 * 1024 * 1024; # 5 GB — stop GC once this much space is free
+  };
+
   system.stateVersion = "24.05";
 }


### PR DESCRIPTION
Run GC daily with 7-day retention (vs weekly/30d globally).
Add min-free/max-free to trigger proactive GC during builds
when free space drops below 1 GB.