### PR TITLE
fix(spore): use lib.mkForce to override gc options from base module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,24 @@ on:
     branches: main
 
 jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v31
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check all configurations evaluate
+      run: |
+        for host in glyph spore zeta; do
+          echo "Evaluating $host..."
+          nix eval .#nixosConfigurations.$host.config.system.build.toplevel.drvPath
+        done
+        echo "Evaluating Rhizome..."
+        nix eval .#darwinConfigurations.Rhizome.system.drvPath
+
   build:
+    needs: eval
     strategy:
       fail-fast: false
       matrix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,12 @@ nixos-rebuild switch --flake .#hostname        # Linux
 nixos-rebuild switch --flake .#spore --target-host root@spore --build-host localhost
 ```
 
+**Checking changes before committing:**
+```bash
+nix-flake eval nixosConfigurations.hostname.config.system.build.toplevel.drvPath
+```
+Evaluates a host's configuration without building it. Catches option conflicts and type errors fast — run this after editing any NixOS module or host config.
+
 **Flake management:**
 ```bash
 nix flake update --commit-lock-file

--- a/hosts/spore/default.nix
+++ b/hosts/spore/default.nix
@@ -52,8 +52,8 @@
 
   # Stricter GC due to limited disk space (30 GB)
   nix.gc = {
-    dates = "daily";
-    options = "--delete-older-than 7d";
+    dates = lib.mkForce "daily";
+    options = lib.mkForce "--delete-older-than 7d";
   };
 
   nix.settings = {


### PR DESCRIPTION
## Summary

- Fix conflicting `nix.gc.dates` and `nix.gc.options` definitions on spore by using `lib.mkForce`, allowing host-level overrides of the base `gc.nix` module defaults
- Add a fast `eval` CI job that evaluates all host configurations (glyph, spore, zeta, Rhizome) without building, gating the full build matrix — catches option conflicts and eval errors before any expensive runners spin up
- Add eval command to CLAUDE.md as a pre-commit check for NixOS config changes