### PR TITLE
fix(spore): use canonical golink with OAuth support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,16 +286,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1765523342,
-        "narHash": "sha256-x1KyVQHnHNSBeuLYtRGUqjVtwv4AZMd2RPhtTPXrR4I=",
-        "owner": "apoxy-dev",
+        "lastModified": 1775592125,
+        "narHash": "sha256-6kVGyNf5X7H7h/Vf8ge18YQPxRzljTlwPRpLdIPjndY=",
+        "owner": "tailscale",
         "repo": "golink",
-        "rev": "17e583241673aa51935ca9e0d559f91a63144d48",
+        "rev": "0c619de1671d3d8c8157ec2584115cdac41cc501",
         "type": "github"
       },
       "original": {
-        "owner": "apoxy-dev",
-        "ref": "dilyevsky/tsnet-1.90-upgrade",
+        "owner": "tailscale",
         "repo": "golink",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     golink = {
-      url = "github:apoxy-dev/golink/dilyevsky/tsnet-1.90-upgrade";
+      url = "github:tailscale/golink";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.systems.follows = "systems";
     };

--- a/hosts/spore/services/default.nix
+++ b/hosts/spore/services/default.nix
@@ -1,8 +1,4 @@
-{
-  config,
-  pkgs,
-  ...
-}: {
+{config, ...}: {
   imports = [
     ./alloy.nix
     ./grafana.nix
@@ -31,11 +27,6 @@
   services.golink = {
     enable = true;
     tailscaleAuthKeyFile = config.age.secrets.tailscale-auth-key.path;
-    package = pkgs.buildGo125Module {
-      pname = "golink";
-      inherit (pkgs.golink) version src ldflags;
-      vendorHash = "sha256-M3Qm25KF6gWtp3K1SigLucgrIJ+5KokMq+Bp7XXaE+o=";
-    };
   };
 
   services.openssh.enable = true;


### PR DESCRIPTION
Reverts the workaround from #344 now that the canonical `tailscale/golink` supports OAuth-based `TS_AUTHKEY` (via `tailscale.com v1.96.1`, well above the v1.90 threshold needed).

## Changes
- `flake.nix`: switch input from `apoxy-dev/golink` fork back to `tailscale/golink`
- `flake.lock`: updated to canonical upstream (2026-04-07)
- `hosts/spore/services/default.nix`: drop `buildGo125Module` package override and unused `pkgs` arg

## Verify
- golink service starts on spore and joins the tailnet using the OAuth key in `tailscale-auth-key.age`

Closes #404