### PR TITLE
feat(glyph): expose ntfy on Tailscale interface

### DIFF
--- a/hosts/glyph/services/ntfy.nix
+++ b/hosts/glyph/services/ntfy.nix
@@ -35,9 +35,11 @@ in {
     enable = true;
     settings = {
       base-url = "http://glyph:2586";
-      listen-http = "127.0.0.1:2586";
+      listen-http = ":2586";
     };
   };
+
+  networking.firewall.interfaces.tailscale0.allowedTCPPorts = [2586];
 
   systemd.services.ntfy-slack-relay = {
     description = "Forward ntfy notifications to Slack";


### PR DESCRIPTION
Bind ntfy to all interfaces and allow port 2586 on tailscale0 only,
so other hosts on the Tailscale network can publish notifications.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>