### PR TITLE
fix(spore): set TS_ADVERTISE_TAGS for golink OAuth auth

### DIFF
--- a/hosts/spore/services/default.nix
+++ b/hosts/spore/services/default.nix
@@ -29,6 +29,8 @@
     tailscaleAuthKeyFile = config.age.secrets.tailscale-auth-key.path;
   };
 
+  systemd.services.golink.environment.TS_ADVERTISE_TAGS = "tag:golink";
+
   services.openssh.enable = true;
   services.tailscale.enable = true;
 }


### PR DESCRIPTION
## Summary

Upstream `tailscale/golink` defaults `--advertise-tags` to `$TS_ADVERTISE_TAGS` (empty if unset), whereas the previous fork (`apoxy-dev/golink`) hardcoded `tag:golink` as the default. With a wiped tsnet state and an OAuth client secret as the auth key, tsnet rejects authentication unless at least one tag is advertised.

Sets `TS_ADVERTISE_TAGS=tag:golink` in the golink systemd service environment so OAuth auth keys work without patching the binary.

## Test plan

- [x] `systemctl status golink` on spore shows `active (running)`
- [x] `go.note-iwato.ts.net` is reachable on the tailnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)