### PR TITLE
chore: disable fail-fast on deploy matrix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,7 @@ jobs:
       cancel-in-progress: false
     environment: ${{ matrix.host }}
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.changes.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
GitHub Actions matrix strategies default to `fail-fast: true`, which cancels all in-progress jobs when any single job fails. This means a failed deploy to one host would abort deploys to other hosts mid-flight.

Set `fail-fast: false` on the `deploy` job so each host deploys independently — a failure on `spore` won't prevent `glyph` or `zeta` from completing.

## Verify

Trigger a deploy with `workflow_dispatch` → `all` and confirm all three host jobs run to completion regardless of individual job outcomes.