### PR TITLE
chore: use semantic PR title for flake update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,14 +17,20 @@ jobs:
           git config --global user.name "github-actions[bot]"
       - name: Update
         run: nix flake update --commit-lock-file
+      - name: Get update details
+        id: update-details
+        run: |
+          body=$(git log -1 --pretty=%B)
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$body" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - uses: peter-evans/create-pull-request@v7
         id: create-pr
         with:
           branch: gh/update-flake
-          title: Update flake inputs
-          body: |
-            Automatic update of flake inputs
+          title: "chore: update flake inputs"
+          body: ${{ steps.update-details.outputs.body }}
           # Use a PAT so that Workflows run on the created PR
           token: ${{ secrets.CREATE_PR_TOKEN }}
       - if: ${{ steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
## Summary

- Changes the auto-generated flake update PR title from `Update flake inputs` to `chore: update flake inputs` to follow the conventional commit style used in this repo
- Replaces the static `Automatic update of flake inputs` body with the commit message generated by `nix flake update --commit-lock-file`, which includes a structured breakdown of exactly which inputs changed and what revisions they moved between

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and verify the created PR has title `chore: update flake inputs`
- [ ] Verify the PR body shows the flake input diff from the lock file update commit