### PR TITLE
feat: notify Slack on build failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,69 @@ jobs:
         attic push rc:main $(which attic)
         nix build .#devShells.${{ matrix.system }}.default -o ./result-devshell
         attic push rc:main ./result-devshell
+    - name: Prepare Slack context
+      if: failure()
+      id: slack-context
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        SHA: ${{ github.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        COMMIT_URL: ${{ github.event.head_commit.url }}
+      run: |
+        echo "short_sha=${SHA:0:7}" >> $GITHUB_OUTPUT
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          echo "trigger=PR <${PR_URL}|#${PR_NUMBER}: ${PR_TITLE}>" >> $GITHUB_OUTPUT
+        else
+          FIRST_LINE=$(printf '%s' "$COMMIT_MESSAGE" | head -1)
+          echo "trigger=push <${COMMIT_URL}|${FIRST_LINE}>" >> $GITHUB_OUTPUT
+        fi
+    - name: Notify Slack on failure
+      if: failure()
+      uses: slackapi/slack-github-action@v2
+      with:
+        webhook: ${{ secrets.SLACK_WEBHOOK_UPDATES_CI }}
+        webhook-type: incoming-webhook
+        payload-templating: true
+        payload: |
+          {
+            "attachments": [
+              {
+                "color": "#CC0000",
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": ":x: CI build failed",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Host*\n${{ matrix.host }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Trigger*\n${{ steps.slack-context.outputs.trigger }}"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}> · <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ steps.slack-context.outputs.short_sha }}> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }


### PR DESCRIPTION
Adds a Slack notification to the `build` job that fires on failure, for both PR and push-to-main contexts.

## Changes

- New `Prepare Slack context` step computes the trigger string (PR or push) and short SHA as step outputs
- New `Notify Slack on failure` step uses `slackapi/slack-github-action@v2` with a Block Kit payload: red-bordered attachment, header, two-column section (host + trigger), and a context line with linked repo, commit, and run URL
- Requires a `SLACK_WEBHOOK_UPDATES_CI` repository secret (incoming webhook for #updates)

## Verify

- Confirm `SLACK_WEBHOOK_UPDATES_CI` secret is set before merging
- Trigger a deliberate build failure on a PR and a push to main to confirm both message shapes render correctly in Slack