### PR TITLE
chore(spore): intentional build failure to test CI notification

### DIFF
--- a/hosts/spore/default.nix
+++ b/hosts/spore/default.nix
@@ -61,5 +61,10 @@
     max-free = 5 * 1024 * 1024 * 1024; # 5 GB — stop GC once this much space is free
   };
 
+  # Intentional build failure to test CI Slack notification — remove after verifying
+  environment.systemPackages = [
+    (pkgs.runCommand "ci-notification-test" {} "exit 1")
+  ];
+
   system.stateVersion = "24.05";
 }


### PR DESCRIPTION
Adds a `runCommand` derivation with `exit 1` to spore's package list. This evaluates correctly (the `.drvPath` is valid) but fails at build time, which should trigger the Slack failure notification added in #454.

**Remove this PR without merging once the notification is confirmed.**