### PR TITLE
feat: surface evaluation warnings in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,23 @@ jobs:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check all configurations evaluate
       run: |
-        for host in glyph spore zeta; do
+        eval_host() {
+          local host="$1"
+          local expr="$2"
           echo "Evaluating $host..."
-          nix eval .#nixosConfigurations.$host.config.system.build.toplevel.drvPath
+          stderr=$(nix eval "$expr" 2>&1 >/dev/null)
+          if [ -n "$stderr" ]; then
+            echo "$stderr"
+            if echo "$stderr" | grep -q "evaluation warning:"; then
+              encoded=$(printf '%s' "$stderr" | python3 -c "import sys; print(sys.stdin.read().replace('%','%25').replace('\n','%0A').replace('\r','%0D'))")
+              echo "::warning title=Evaluation warnings ($host)::${encoded}"
+            fi
+          fi
+        }
+        for host in glyph spore zeta; do
+          eval_host "$host" ".#nixosConfigurations.$host.config.system.build.toplevel.drvPath"
         done
-        echo "Evaluating Rhizome..."
-        nix eval .#darwinConfigurations.Rhizome.system.drvPath
+        eval_host "Rhizome" ".#darwinConfigurations.Rhizome.system.drvPath"
 
   build:
     needs: eval


### PR DESCRIPTION
Capture stderr from `nix eval` during the CI eval job and emit GitHub Actions warning annotations when evaluation warnings are detected. The step also fails so the `build` job is blocked, making warnings impossible to miss on PRs.

Closes #274

## What changed
- Refactored the eval loop into an `eval_host` function
- Stderr is captured separately from stdout
- Any `evaluation warning:` in stderr triggers a `::warning::` annotation (visible in the PR checks summary) and fails the step
- Multi-line warnings are encoded with `%0A` so the full text appears in the annotation
- All hosts are checked before exiting, so all warnings are reported in a single run

## Verify
Check that a config with an evaluation warning causes the eval job to fail and shows the warning text as an annotation on the PR.