### PR TITLE
chore: address evaluation warnings

### DIFF
--- a/hosts/glyph/home.nix
+++ b/hosts/glyph/home.nix
@@ -12,7 +12,7 @@
     enableMcpIntegration = true;
     web.enable = true;
     web.extraArgs = ["--port" "8890" "--hostname" "0.0.0.0"];
-    rules = builtins.readFile "${llm-profile}/README.md";
+    context = builtins.readFile "${llm-profile}/README.md";
     settings = {
       model = "anthropic/claude-opus-4-6";
       small_model = "anthropic/claude-haiku-4-5";

--- a/hosts/zeta/hardware.nix
+++ b/hosts/zeta/hardware.nix
@@ -8,7 +8,6 @@
     inputs.nixos-hardware.nixosModules.raspberry-pi-4
   ];
   boot = {
-    kernelPackages = pkgs.linuxKernel.packages.linux_rpi4;
     initrd.availableKernelModules = ["xhci_pci" "usbhid" "usb_storage"];
     loader = {
       grub.enable = false;

--- a/modules/home/development.nix
+++ b/modules/home/development.nix
@@ -42,7 +42,7 @@ in {
       programs.claude-code = {
         enable = true;
         enableMcpIntegration = true;
-        memory.source = "${llm-profile}/README.md";
+        context = "${llm-profile}/README.md";
         settings = {
           model = "sonnet";
           # Disabled in favor of Basic Memory MCP for cross-device access

--- a/modules/home/editor.nix
+++ b/modules/home/editor.nix
@@ -18,6 +18,8 @@ in {
     programs.neovim = {
       enable = true;
       defaultEditor = true;
+      withRuby = false;
+      withPython3 = false;
       plugins = with pkgs.vimPlugins; [catppuccin-nvim lualine-nvim];
       initLua = ''
         require("catppuccin").setup {

--- a/modules/home/gpg.nix
+++ b/modules/home/gpg.nix
@@ -25,6 +25,7 @@ in {
     programs.git.signing = {
       key = "F88C08579051AB48";
       signByDefault = true;
+      format = "openpgp";
     };
 
     services.gpg-agent = {

--- a/modules/home/scm.nix
+++ b/modules/home/scm.nix
@@ -51,6 +51,7 @@ in {
 
       programs.git = {
         enable = true;
+        signing.format = lib.mkDefault null;
         settings = {
           user = {
             name = "✿ corey";


### PR DESCRIPTION
Addresses all actionable evaluation warnings surfaced by #457.

## Changes

| File | Warning fixed |
|---|---|
| `modules/home/editor.nix` | `programs.neovim.withRuby` and `programs.neovim.withPython3` — explicitly adopt new defaults (`false`) |
| `modules/home/gpg.nix` | `programs.git.signing.format` — explicitly set to `"openpgp"` to preserve GPG signing on Rhizome |
| `modules/home/scm.nix` | `programs.git.signing.format` — set `mkDefault null` as base so hosts without GPG adopt the new default silently |
| `modules/home/development.nix` | `programs.claude-code.memory.source` → `programs.claude-code.context` |
| `hosts/glyph/home.nix` | `programs.opencode.rules` → `programs.opencode.context` |
| `hosts/zeta/hardware.nix` | `linux-rpi series` deprecation — removed explicit `linux_rpi4` kernel package; `nixos-hardware.nixosModules.raspberry-pi-4` (already imported) handles the kernel |

## Not fixed

One warning remains on glyph: `'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`. This originates from the `attic` flake (a transitive dependency via `services.atticd`), not from this repo's code. It requires an upstream fix.