### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776184304,
-        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
+        "lastModified": 1776373306,
+        "narHash": "sha256-iAJIzHngGZeLIkjzuuWI6VBsYJ1n89a/Esq0m8R1vjs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
+        "rev": "d401492e2acd4fea42f7705a3c266cea739c9c36",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776318988,
-        "narHash": "sha256-W4Hk131VgNH/S0pTI+UF6BVWb1Bf/xpSR7qw4Je0S9E=",
+        "lastModified": 1776404967,
+        "narHash": "sha256-tfOYhm4r8KgbjizD5prkfSa7dKUiRdBBaZm2Wahm50Q=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "434120cfdca0e4628c7087605e82e3db51bd0690",
+        "rev": "6bdf2eccd227dd6dc9a1ad342c21782516ad87d9",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776319195,
-        "narHash": "sha256-8GaQ8iiO1zy9o0tsjEzqz4G1gA9t/aoB+/7m3XD3GkQ=",
+        "lastModified": 1776408746,
+        "narHash": "sha256-l3THrF84pUyiADK6xmwqyah+X3rVGbMXqiN7ReckTno=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "45066f511925ac690a0cf54078cb633b8bc974a3",
+        "rev": "05359b1569f81d93bcfd5e38d6e5e9b007f020f1",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs-stable-25-11": {
       "locked": {
-        "lastModified": 1776067740,
-        "narHash": "sha256-B35lpsqnSZwn1Lmz06BpwF7atPgFmUgw1l8KAV3zpVQ=",
+        "lastModified": 1776221942,
+        "narHash": "sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7e495b747b51f95ae15e74377c5ce1fe69c1765f",
+        "rev": "1766437c5509f444c1b15331e82b8b6a9b967000",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/3c7524c68348ef79ce48308e0978611a050089b2?narHash=sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc%3D' (2026-04-14)
  → 'github:nix-community/home-manager/d401492e2acd4fea42f7705a3c266cea739c9c36?narHash=sha256-iAJIzHngGZeLIkjzuuWI6VBsYJ1n89a/Esq0m8R1vjs%3D' (2026-04-16)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/434120cfdca0e4628c7087605e82e3db51bd0690?narHash=sha256-W4Hk131VgNH/S0pTI%2BUF6BVWb1Bf/xpSR7qw4Je0S9E%3D' (2026-04-16)
  → 'github:homebrew/homebrew-cask/6bdf2eccd227dd6dc9a1ad342c21782516ad87d9?narHash=sha256-tfOYhm4r8KgbjizD5prkfSa7dKUiRdBBaZm2Wahm50Q%3D' (2026-04-17)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/45066f511925ac690a0cf54078cb633b8bc974a3?narHash=sha256-8GaQ8iiO1zy9o0tsjEzqz4G1gA9t/aoB%2B/7m3XD3GkQ%3D' (2026-04-16)
  → 'github:homebrew/homebrew-core/05359b1569f81d93bcfd5e38d6e5e9b007f020f1?narHash=sha256-l3THrF84pUyiADK6xmwqyah%2BX3rVGbMXqiN7ReckTno%3D' (2026-04-17)
• Updated input 'nixpkgs-stable-25-11':
    'github:nixos/nixpkgs/7e495b747b51f95ae15e74377c5ce1fe69c1765f?narHash=sha256-B35lpsqnSZwn1Lmz06BpwF7atPgFmUgw1l8KAV3zpVQ%3D' (2026-04-13)
  → 'github:nixos/nixpkgs/1766437c5509f444c1b15331e82b8b6a9b967000?narHash=sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM%3D' (2026-04-15)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'