### PR TITLE
feat: add lobtop darwin host

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -126,6 +126,12 @@
             hostname = "Stroma";
             username = "corey";
           };
+
+          lobtop = mkDarwinHost {
+            hostname = "LOB-MG2QJH49W7";
+            username = "corey";
+            configDir = "lobtop";
+          };
         };
 
         deploy = {

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
 
           lobtop = mkDarwinHost {
             hostname = "LOB-MG2QJH49W7";
-            username = "corey";
+            username = "corey.johns";
             configDir = "lobtop";
           };
         };

--- a/home/programs/starship.nix
+++ b/home/programs/starship.nix
@@ -88,7 +88,7 @@
         style = "bg:color_orange fg:color_fg0";
         disabled = false;
         aliases = {
-          "LOB-MG2QJH49W7" = "Lobtop";
+          "LOB-MG2QJH49W7" = "lobtop";
         };
       };
       directory = {

--- a/home/programs/starship.nix
+++ b/home/programs/starship.nix
@@ -87,6 +87,9 @@
         format = "[@$hostname ]($style)";
         style = "bg:color_orange fg:color_fg0";
         disabled = false;
+        aliases = {
+          "LOB-MG2QJH49W7" = "Lobtop";
+        };
       };
       directory = {
         style = "fg:color_fg0 bg:color_yellow";

--- a/hosts/lobtop/default.nix
+++ b/hosts/lobtop/default.nix
@@ -1,8 +1,4 @@
-{
-  config,
-  pkgs,
-  ...
-}: {
+_: {
   imports = [
     ./dock.nix
     ./hardware.nix

--- a/hosts/lobtop/default.nix
+++ b/hosts/lobtop/default.nix
@@ -1,0 +1,18 @@
+{
+  config,
+  pkgs,
+  ...
+}: {
+  imports = [
+    ./dock.nix
+    ./hardware.nix
+    ./programs.nix
+  ];
+
+  rc.darwin.defaults = {
+    fonts = true;
+    homebrew = true;
+    security = true;
+    system = true;
+  };
+}

--- a/hosts/lobtop/dock.nix
+++ b/hosts/lobtop/dock.nix
@@ -4,9 +4,16 @@ _: {
     largesize = 86;
     persistent-apps = [
       "/System/Volumes/Preboot/Cryptexes/App/System/Applications/Safari.app"
+      "/System/Applications/Mail.app"
+      "/Applications/Zed.app"
+      "/Applications/rootshell.app"
+      "/Applications/Reeder.app"
       "/System/Applications/Calendar.app"
       "/System/Applications/Reminders.app"
       "/System/Applications/Notes.app"
+      "/Applications/Things3.app"
+      "/Applications/Craft.app"
+      "/System/Applications/Messages.app"
       "/Applications/Slack.app"
     ];
   };

--- a/hosts/lobtop/dock.nix
+++ b/hosts/lobtop/dock.nix
@@ -11,7 +11,7 @@ _: {
       "/System/Applications/Calendar.app"
       "/System/Applications/Reminders.app"
       "/System/Applications/Notes.app"
-      "/Applications/Things3.app"
+      "/Applications/Things.app"
       "/Applications/Craft.app"
       "/System/Applications/Messages.app"
       "/Applications/Slack.app"

--- a/hosts/lobtop/dock.nix
+++ b/hosts/lobtop/dock.nix
@@ -1,8 +1,4 @@
-{
-  config,
-  pkgs,
-  ...
-}: {
+_: {
   system.defaults.dock = {
     tilesize = 42;
     largesize = 86;

--- a/hosts/lobtop/dock.nix
+++ b/hosts/lobtop/dock.nix
@@ -1,0 +1,17 @@
+{
+  config,
+  pkgs,
+  ...
+}: {
+  system.defaults.dock = {
+    tilesize = 42;
+    largesize = 86;
+    persistent-apps = [
+      "/System/Volumes/Preboot/Cryptexes/App/System/Applications/Safari.app"
+      "/System/Applications/Calendar.app"
+      "/System/Applications/Reminders.app"
+      "/System/Applications/Notes.app"
+      "/Applications/Slack.app"
+    ];
+  };
+}

--- a/hosts/lobtop/hardware.nix
+++ b/hosts/lobtop/hardware.nix
@@ -2,7 +2,7 @@ _: {
   users.users.corey = {
     home = "/Users/corey";
   };
-  system.primaryUser = "corey";
+  system.primaryUser = "corey.johns";
 
   networking.hostName = "LOB-MG2QJH49W7";
 

--- a/hosts/lobtop/hardware.nix
+++ b/hosts/lobtop/hardware.nix
@@ -1,8 +1,4 @@
-{
-  config,
-  pkgs,
-  ...
-}: {
+_: {
   users.users.corey = {
     home = "/Users/corey";
   };

--- a/hosts/lobtop/hardware.nix
+++ b/hosts/lobtop/hardware.nix
@@ -1,6 +1,6 @@
 _: {
-  users.users.corey = {
-    home = "/Users/corey";
+  users.users."corey.johns" = {
+    home = "/Users/corey.johns";
   };
   system.primaryUser = "corey.johns";
 

--- a/hosts/lobtop/hardware.nix
+++ b/hosts/lobtop/hardware.nix
@@ -1,0 +1,15 @@
+{
+  config,
+  pkgs,
+  ...
+}: {
+  users.users.corey = {
+    home = "/Users/corey";
+  };
+  system.primaryUser = "corey";
+
+  networking.hostName = "LOB-MG2QJH49W7";
+
+  system.stateVersion = 5;
+  nixpkgs.hostPlatform = "aarch64-darwin";
+}

--- a/hosts/lobtop/key.pub
+++ b/hosts/lobtop/key.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOXjSJpXPnmfSS87TTtN2a+VM/jBQav5JRe5GaBz75gC corey.johns@lobtop

--- a/hosts/lobtop/programs.nix
+++ b/hosts/lobtop/programs.nix
@@ -1,8 +1,4 @@
-{
-  config,
-  pkgs,
-  ...
-}: {
+{pkgs, ...}: {
   environment.systemPackages = with pkgs; [
     m-cli
     mas

--- a/hosts/lobtop/programs.nix
+++ b/hosts/lobtop/programs.nix
@@ -1,0 +1,18 @@
+{
+  config,
+  pkgs,
+  ...
+}: {
+  environment.systemPackages = with pkgs; [
+    m-cli
+    mas
+    the-unarchiver
+  ];
+
+  homebrew = {
+    enable = true;
+    # N.B.: Removed entries in `masApps` require manual uninstallation
+    masApps = {
+    };
+  };
+}

--- a/hosts/lobtop/programs.nix
+++ b/hosts/lobtop/programs.nix
@@ -11,4 +11,8 @@
     masApps = {
     };
   };
+
+  programs.craft = {
+    enable = true;
+  };
 }

--- a/justfile
+++ b/justfile
@@ -1,7 +1,8 @@
 # Build the system config and switch to it when running `just` with no args
 default: switch
 
-hostname := `hostname | cut -d "." -f 1`
+# Substitute work laptop hostname if necessary
+hostname := `h=$(hostname | cut -d "." -f 1); case "$h" in LOB-*) echo "lobtop";; *) echo "$h";; esac`
 
 [macos]
 switch host=hostname:

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -23,13 +23,14 @@ inputs @ {
   mkHomeManager = {
     username,
     hostname,
+    configDir,
     system,
     showBatteryStatus,
     lightweight ? false,
   }: let
     pkgs-stable-25-11 = import nixpkgs-stable-25-11 {inherit system;};
     pkgs-stable-24-05 = import nixpkgs-stable-24-05 {inherit system;};
-    hostHomePath = ./../hosts/${hostname}/home.nix;
+    hostHomePath = ./../hosts/${configDir}/home.nix;
     hostHomeConfig =
       if builtins.pathExists hostHomePath
       then hostHomePath
@@ -57,6 +58,7 @@ inputs @ {
     system,
     username,
     lightweight ? false,
+    configDir ? hostname,
   }:
     nixpkgs.lib.nixosSystem {
       inherit system;
@@ -70,11 +72,11 @@ inputs @ {
         disko.nixosModules.disko
         ./../modules/base
         ./../modules/nixos
-        ./../hosts/${hostname}
+        ./../hosts/${configDir}
         agenix.nixosModules.default
         home-manager.nixosModules.home-manager
         (mkHomeManager {
-          inherit username hostname system lightweight;
+          inherit username hostname system lightweight configDir;
           showBatteryStatus = false;
         })
         {
@@ -90,6 +92,7 @@ inputs @ {
     hostname,
     username,
     lightweight ? false,
+    configDir ? hostname,
   }: let
     system = "aarch64-darwin";
   in
@@ -105,10 +108,10 @@ inputs @ {
         nix-homebrew.darwinModules.nix-homebrew
         ./../modules/base
         ./../modules/darwin
-        ./../hosts/${hostname}
+        ./../hosts/${configDir}
         home-manager.darwinModules.home-manager
         (mkHomeManager {
-          inherit username hostname system lightweight;
+          inherit username hostname system lightweight configDir;
           showBatteryStatus = true;
         })
         {

--- a/lib/keys.nix
+++ b/lib/keys.nix
@@ -8,6 +8,7 @@ let
       value = readKey h;
     }) [
       "glyph"
+      "lobtop"
       "Rhizome"
       "spore"
       "Stroma"

--- a/modules/nixos/ssh.nix
+++ b/modules/nixos/ssh.nix
@@ -16,6 +16,7 @@
     keys.Rhizome
     keys.glyph
     keys.Stroma
+    keys.lobtop
   ];
 
   security.pam.sshAgentAuth.authorizedKeysFiles = lib.mkForce ["/etc/ssh/authorized_keys.d/%u"];


### PR DESCRIPTION
## Summary

- Adds a new macOS host for the work laptop (`LOB-MG2QJH49W7`), configured under `hosts/lobtop` and registered as `darwinConfigurations.lobtop`
- Adds a `configDir` parameter to `mkDarwinHost` (and `mkNixosHost` for consistency) so the flake key and config directory can differ from the actual system hostname
- Registers the lobtop SSH key in `lib/keys.nix` and authorizes it for `users.users.mu` in `modules/nixos/ssh.nix`

## Test plan

- [ ] `nix-flake eval darwinConfigurations.lobtop.system.drvPath` evaluates cleanly
- [ ] Deploy on the work laptop: `nh darwin switch .#lobtop`
- [ ] Verify existing hosts (`Rhizome`, `Stroma`) still evaluate cleanly