### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776373306,
-        "narHash": "sha256-iAJIzHngGZeLIkjzuuWI6VBsYJ1n89a/Esq0m8R1vjs=",
+        "lastModified": 1776454077,
+        "narHash": "sha256-7zSUFWsU0+jlD7WB3YAxQ84Z/iJurA5hKPm8EfEyGJk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d401492e2acd4fea42f7705a3c266cea739c9c36",
+        "rev": "565e5349208fe7d0831ef959103c9bafbeac0681",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776404967,
-        "narHash": "sha256-tfOYhm4r8KgbjizD5prkfSa7dKUiRdBBaZm2Wahm50Q=",
+        "lastModified": 1776490402,
+        "narHash": "sha256-TmhaYARBBsLcZeUQ1bSSLN1se/fKLIOWcgDmFqpCLhY=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "6bdf2eccd227dd6dc9a1ad342c21782516ad87d9",
+        "rev": "18bf4929b2863a4663697b443b4e7e55ba6b3fb3",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776408746,
-        "narHash": "sha256-l3THrF84pUyiADK6xmwqyah+X3rVGbMXqiN7ReckTno=",
+        "lastModified": 1776485623,
+        "narHash": "sha256-vY7AkhubqVrBBfPXd/0mq2auj8COoyqRXIjB5uDtOFM=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "05359b1569f81d93bcfd5e38d6e5e9b007f020f1",
+        "rev": "6e2a622f3d07b0d6cebbf2b439f2b0a631266f55",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs-stable-25-11": {
       "locked": {
-        "lastModified": 1776221942,
-        "narHash": "sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM=",
+        "lastModified": 1776434932,
+        "narHash": "sha256-gyqXNMgk3sh+ogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1766437c5509f444c1b15331e82b8b6a9b967000",
+        "rev": "c7f47036d3df2add644c46d712d14262b7d86c0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/d401492e2acd4fea42f7705a3c266cea739c9c36?narHash=sha256-iAJIzHngGZeLIkjzuuWI6VBsYJ1n89a/Esq0m8R1vjs%3D' (2026-04-16)
  → 'github:nix-community/home-manager/565e5349208fe7d0831ef959103c9bafbeac0681?narHash=sha256-7zSUFWsU0%2BjlD7WB3YAxQ84Z/iJurA5hKPm8EfEyGJk%3D' (2026-04-17)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/6bdf2eccd227dd6dc9a1ad342c21782516ad87d9?narHash=sha256-tfOYhm4r8KgbjizD5prkfSa7dKUiRdBBaZm2Wahm50Q%3D' (2026-04-17)
  → 'github:homebrew/homebrew-cask/18bf4929b2863a4663697b443b4e7e55ba6b3fb3?narHash=sha256-TmhaYARBBsLcZeUQ1bSSLN1se/fKLIOWcgDmFqpCLhY%3D' (2026-04-18)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/05359b1569f81d93bcfd5e38d6e5e9b007f020f1?narHash=sha256-l3THrF84pUyiADK6xmwqyah%2BX3rVGbMXqiN7ReckTno%3D' (2026-04-17)
  → 'github:homebrew/homebrew-core/6e2a622f3d07b0d6cebbf2b439f2b0a631266f55?narHash=sha256-vY7AkhubqVrBBfPXd/0mq2auj8COoyqRXIjB5uDtOFM%3D' (2026-04-18)
• Updated input 'nixpkgs-stable-25-11':
    'github:nixos/nixpkgs/1766437c5509f444c1b15331e82b8b6a9b967000?narHash=sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM%3D' (2026-04-15)
  → 'github:nixos/nixpkgs/c7f47036d3df2add644c46d712d14262b7d86c0c?narHash=sha256-gyqXNMgk3sh%2BogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk%3D' (2026-04-17)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'