### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776454077,
-        "narHash": "sha256-7zSUFWsU0+jlD7WB3YAxQ84Z/iJurA5hKPm8EfEyGJk=",
+        "lastModified": 1776562531,
+        "narHash": "sha256-Lh5Ns9DI67E+lSMOCGK0S+mFPy0mz0yOGiJTUXiR9JI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "565e5349208fe7d0831ef959103c9bafbeac0681",
+        "rev": "5b56ad02dc643808b8af6d5f3ff179e2ce9593f4",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776490402,
-        "narHash": "sha256-TmhaYARBBsLcZeUQ1bSSLN1se/fKLIOWcgDmFqpCLhY=",
+        "lastModified": 1776577437,
+        "narHash": "sha256-yXn9dW2XNs9+7IbeabfZaQ8crBYFOlIu2Wx4FIJZr+s=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "18bf4929b2863a4663697b443b4e7e55ba6b3fb3",
+        "rev": "b288261e2bab164ffd160e0e0c1b5eef40ba0fe6",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776485623,
-        "narHash": "sha256-vY7AkhubqVrBBfPXd/0mq2auj8COoyqRXIjB5uDtOFM=",
+        "lastModified": 1776580749,
+        "narHash": "sha256-p8pDHZc++zHwq389bqa3jRBxyWaxfkqhGWA1Krs7c1c=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "6e2a622f3d07b0d6cebbf2b439f2b0a631266f55",
+        "rev": "fbe2e15ece4088aa2538be86c67f97fa1c5ab6be",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775970782,
-        "narHash": "sha256-7jt9Vpm48Yy5yAWigYpde+HxtYEpEuyzIQJF4VYehhk=",
+        "lastModified": 1776575850,
+        "narHash": "sha256-28Gqz0GDpGsBv8GtAn2dywEQRr+CtTDsD5J7VD6icBE=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "bedba5989b04614fc598af9633033b95a937933f",
+        "rev": "3b9653a107c736222b5ae0d4036dd3b885219065",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/565e5349208fe7d0831ef959103c9bafbeac0681?narHash=sha256-7zSUFWsU0%2BjlD7WB3YAxQ84Z/iJurA5hKPm8EfEyGJk%3D' (2026-04-17)
  → 'github:nix-community/home-manager/5b56ad02dc643808b8af6d5f3ff179e2ce9593f4?narHash=sha256-Lh5Ns9DI67E%2BlSMOCGK0S%2BmFPy0mz0yOGiJTUXiR9JI%3D' (2026-04-19)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/18bf4929b2863a4663697b443b4e7e55ba6b3fb3?narHash=sha256-TmhaYARBBsLcZeUQ1bSSLN1se/fKLIOWcgDmFqpCLhY%3D' (2026-04-18)
  → 'github:homebrew/homebrew-cask/b288261e2bab164ffd160e0e0c1b5eef40ba0fe6?narHash=sha256-yXn9dW2XNs9%2B7IbeabfZaQ8crBYFOlIu2Wx4FIJZr%2Bs%3D' (2026-04-19)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/6e2a622f3d07b0d6cebbf2b439f2b0a631266f55?narHash=sha256-vY7AkhubqVrBBfPXd/0mq2auj8COoyqRXIjB5uDtOFM%3D' (2026-04-18)
  → 'github:homebrew/homebrew-core/fbe2e15ece4088aa2538be86c67f97fa1c5ab6be?narHash=sha256-p8pDHZc%2B%2BzHwq389bqa3jRBxyWaxfkqhGWA1Krs7c1c%3D' (2026-04-19)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/bedba5989b04614fc598af9633033b95a937933f?narHash=sha256-7jt9Vpm48Yy5yAWigYpde%2BHxtYEpEuyzIQJF4VYehhk%3D' (2026-04-12)
  → 'github:nix-community/nix-index-database/3b9653a107c736222b5ae0d4036dd3b885219065?narHash=sha256-28Gqz0GDpGsBv8GtAn2dywEQRr%2BCtTDsD5J7VD6icBE%3D' (2026-04-19)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'