### PR TITLE
feat(glyph): expose basic-memory notes as Samba share

### DIFF
--- a/hosts/glyph/services/samba.nix
+++ b/hosts/glyph/services/samba.nix
@@ -22,6 +22,7 @@
       Archive = mkShare "/mnt/archive" "mu" "users";
       Backup = mkShare "/mnt/backup" "mu" "users" // {"fruit:time machine" = "yes";};
       Media = mkShare "/mnt/media" config.services.jellyfin.user config.services.jellyfin.group;
+      Notes = mkShare "/var/lib/basic-memory/basic-memory" "basic-memory" "basic-memory";
       Torrents = mkShare "/mnt/torrents" config.services.transmission.user config.services.transmission.group;
       Unsorted = mkShare "/mnt/unsorted" "mu" "users";
     };


### PR DESCRIPTION
## Summary

- Adds a `Notes` Samba share pointing at `/var/lib/basic-memory/basic-memory`
- Uses `force user = basic-memory` so Obsidian (and any other client) can write into the vault (e.g. create `.obsidian/` config) without needing permission changes to the notes directory
- Share is Tailscale-only (firewall not opened), consistent with other shares

## To use

Mount `smb://glyph.note-iwato.ts.net/Notes` on Rhizome (or any Tailscale device), then open the mount as an Obsidian vault.