### PR TITLE
feat(Rhizome): add things3-cli package and darwin module

### DIFF
--- a/hosts/Rhizome/programs.nix
+++ b/hosts/Rhizome/programs.nix
@@ -96,4 +96,8 @@
     enable = true;
     startOnActivation = true;
   };
+
+  programs.things3-cli = {
+    enable = true;
+  };
 }

--- a/modules/darwin/programs/default.nix
+++ b/modules/darwin/programs/default.nix
@@ -11,5 +11,6 @@
     ./roon.nix
     ./scroll-reverser.nix
     ./soundsource.nix
+    ./things3-cli.nix
   ];
 }

--- a/modules/darwin/programs/things3-cli.nix
+++ b/modules/darwin/programs/things3-cli.nix
@@ -1,0 +1,17 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.programs.things3-cli;
+in {
+  options.programs.things3-cli = {
+    enable = mkEnableOption "things3-cli, a CLI for Things 3";
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [pkgs.things3-cli];
+  };
+}

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -27,4 +27,7 @@ self: super: {
 
   # Ungoogled Chromium with privacy enhancements
   ungoogled-chromium = super.callPackage ./../packages/ungoogled-chromium/package.nix {};
+
+  # CLI for Things 3
+  things3-cli = super.callPackage ./../packages/things3-cli/package.nix {};
 }

--- a/packages/things3-cli/package.nix
+++ b/packages/things3-cli/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  nix-update-script,
+}:
+buildGoModule {
+  pname = "things3-cli";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "ossianhempel";
+    repo = "things3-cli";
+    rev = "v0.2.0";
+    hash = "sha256-1YBBOYaCrP7/K1ADJter+iEETNk57Z6UMZY4/+F5iKw=";
+  };
+
+  vendorHash = "sha256-tN903swhctln5f23UQvjdHfLnunzah4Jr+NdsEHG3nI=";
+
+  # Tests require Things 3 database and app running on macOS
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script {};
+
+  meta = with lib; {
+    description = "CLI for Things 3 by Cultured Code, implemented in Go";
+    homepage = "https://github.com/ossianhempel/things3-cli";
+    license = licenses.mit;
+    mainProgram = "things";
+    platforms = platforms.darwin;
+  };
+}


### PR DESCRIPTION
Package things3-cli v0.2.0 (Go CLI for Things 3) from source, expose it
via the custom-packages overlay, add a programs.things3-cli darwin module,
and enable it for the Rhizome host.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>