### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773889306,
-        "narHash": "sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw=",
+        "lastModified": 1776613567,
+        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5ad85c82cc52264f4beddc934ba57f3789f28347",
+        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776562531,
-        "narHash": "sha256-Lh5Ns9DI67E+lSMOCGK0S+mFPy0mz0yOGiJTUXiR9JI=",
+        "lastModified": 1776661682,
+        "narHash": "sha256-X32LTSDqUdVqMy85WYdRgyt0I75wc4Lhi9j+lrCDR8w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5b56ad02dc643808b8af6d5f3ff179e2ce9593f4",
+        "rev": "4bfce11ea820df0359f73736fd59c7e8f53641a6",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776577437,
-        "narHash": "sha256-yXn9dW2XNs9+7IbeabfZaQ8crBYFOlIu2Wx4FIJZr+s=",
+        "lastModified": 1776664183,
+        "narHash": "sha256-8e72JYcGIKx1rFZVtNA6NXvWZx6jzexJa1Bv2dHlSaQ=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "b288261e2bab164ffd160e0e0c1b5eef40ba0fe6",
+        "rev": "a282f543f9af03ba4414f258a103b05248589a0d",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776580749,
-        "narHash": "sha256-p8pDHZc++zHwq389bqa3jRBxyWaxfkqhGWA1Krs7c1c=",
+        "lastModified": 1776667880,
+        "narHash": "sha256-Wu+9kGRVOC7mMaUM20ZXdC2LeHmAWIvo5rmuxvZZzmo=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "fbe2e15ece4088aa2538be86c67f97fa1c5ab6be",
+        "rev": "f7dbbe93c6e6be912a8b87153999cacecc8ccd90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/5ad85c82cc52264f4beddc934ba57f3789f28347?narHash=sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw%3D' (2026-03-19)
  → 'github:nix-community/disko/32f4236bfc141ae930b5ba2fb604f561fed5219d?narHash=sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI%3D' (2026-04-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5b56ad02dc643808b8af6d5f3ff179e2ce9593f4?narHash=sha256-Lh5Ns9DI67E%2BlSMOCGK0S%2BmFPy0mz0yOGiJTUXiR9JI%3D' (2026-04-19)
  → 'github:nix-community/home-manager/4bfce11ea820df0359f73736fd59c7e8f53641a6?narHash=sha256-X32LTSDqUdVqMy85WYdRgyt0I75wc4Lhi9j%2BlrCDR8w%3D' (2026-04-20)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/b288261e2bab164ffd160e0e0c1b5eef40ba0fe6?narHash=sha256-yXn9dW2XNs9%2B7IbeabfZaQ8crBYFOlIu2Wx4FIJZr%2Bs%3D' (2026-04-19)
  → 'github:homebrew/homebrew-cask/a282f543f9af03ba4414f258a103b05248589a0d?narHash=sha256-8e72JYcGIKx1rFZVtNA6NXvWZx6jzexJa1Bv2dHlSaQ%3D' (2026-04-20)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/fbe2e15ece4088aa2538be86c67f97fa1c5ab6be?narHash=sha256-p8pDHZc%2B%2BzHwq389bqa3jRBxyWaxfkqhGWA1Krs7c1c%3D' (2026-04-19)
  → 'github:homebrew/homebrew-core/f7dbbe93c6e6be912a8b87153999cacecc8ccd90?narHash=sha256-Wu%2B9kGRVOC7mMaUM20ZXdC2LeHmAWIvo5rmuxvZZzmo%3D' (2026-04-20)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'