### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776661682,
-        "narHash": "sha256-X32LTSDqUdVqMy85WYdRgyt0I75wc4Lhi9j+lrCDR8w=",
+        "lastModified": 1776721614,
+        "narHash": "sha256-zGuW7C4tsScib2560yE5VV6lY/MdRs30aU9cbg3RP+U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4bfce11ea820df0359f73736fd59c7e8f53641a6",
+        "rev": "c555a4a34a260493be5adb795c54e013c58f2d34",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776664183,
-        "narHash": "sha256-8e72JYcGIKx1rFZVtNA6NXvWZx6jzexJa1Bv2dHlSaQ=",
+        "lastModified": 1776738798,
+        "narHash": "sha256-/ztLPP7c1eZpTVLiWZ8WU8Tr17bfkGnl4PfUdGrL9mg=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "a282f543f9af03ba4414f258a103b05248589a0d",
+        "rev": "18875f5fc1e2553ef80fb5c582efb003c687d241",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776667880,
-        "narHash": "sha256-Wu+9kGRVOC7mMaUM20ZXdC2LeHmAWIvo5rmuxvZZzmo=",
+        "lastModified": 1776754221,
+        "narHash": "sha256-idNvaZVKELz6dV6sC+SO02aigMz7EHlbCTLQSleAvpY=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "f7dbbe93c6e6be912a8b87153999cacecc8ccd90",
+        "rev": "ba02c9d346bc890ec2f9d1516863bc6d5ce2955f",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/4bfce11ea820df0359f73736fd59c7e8f53641a6?narHash=sha256-X32LTSDqUdVqMy85WYdRgyt0I75wc4Lhi9j%2BlrCDR8w%3D' (2026-04-20)
  → 'github:nix-community/home-manager/c555a4a34a260493be5adb795c54e013c58f2d34?narHash=sha256-zGuW7C4tsScib2560yE5VV6lY/MdRs30aU9cbg3RP%2BU%3D' (2026-04-20)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/a282f543f9af03ba4414f258a103b05248589a0d?narHash=sha256-8e72JYcGIKx1rFZVtNA6NXvWZx6jzexJa1Bv2dHlSaQ%3D' (2026-04-20)
  → 'github:homebrew/homebrew-cask/18875f5fc1e2553ef80fb5c582efb003c687d241?narHash=sha256-/ztLPP7c1eZpTVLiWZ8WU8Tr17bfkGnl4PfUdGrL9mg%3D' (2026-04-21)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/f7dbbe93c6e6be912a8b87153999cacecc8ccd90?narHash=sha256-Wu%2B9kGRVOC7mMaUM20ZXdC2LeHmAWIvo5rmuxvZZzmo%3D' (2026-04-20)
  → 'github:homebrew/homebrew-core/ba02c9d346bc890ec2f9d1516863bc6d5ce2955f?narHash=sha256-idNvaZVKELz6dV6sC%2BSO02aigMz7EHlbCTLQSleAvpY%3D' (2026-04-21)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9?narHash=sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM%3D' (2026-04-14)
  → 'github:NixOS/nixpkgs/b12141ef619e0a9c1c84dc8c684040326f27cdcc?narHash=sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24%3D' (2026-04-18)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'