### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775585728,
-        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776721614,
-        "narHash": "sha256-zGuW7C4tsScib2560yE5VV6lY/MdRs30aU9cbg3RP+U=",
+        "lastModified": 1776777932,
+        "narHash": "sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c555a4a34a260493be5adb795c54e013c58f2d34",
+        "rev": "5d5640599a0050b994330328b9fd45709c909720",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776738798,
-        "narHash": "sha256-/ztLPP7c1eZpTVLiWZ8WU8Tr17bfkGnl4PfUdGrL9mg=",
+        "lastModified": 1776839947,
+        "narHash": "sha256-AXWzCRMLMrjHAm7PxGqiHbFbm0p54Y4YUkxbJxMaG9M=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "18875f5fc1e2553ef80fb5c582efb003c687d241",
+        "rev": "32f12c76fa73da5142708eb9fdabeaea75ab88e3",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776754221,
-        "narHash": "sha256-idNvaZVKELz6dV6sC+SO02aigMz7EHlbCTLQSleAvpY=",
+        "lastModified": 1776840796,
+        "narHash": "sha256-4NeqnM4JKnmw3ow0ec0TBTBYFbXbVdvtpqTj+C0sqEs=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "ba02c9d346bc890ec2f9d1516863bc6d5ce2955f",
+        "rev": "bcac962a0cb666729b9aac358307c607808883bb",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776575850,
-        "narHash": "sha256-28Gqz0GDpGsBv8GtAn2dywEQRr+CtTDsD5J7VD6icBE=",
+        "lastModified": 1776829403,
+        "narHash": "sha256-oHVcvP2Ahhj1KUsEzp+2BQF55/r5VSa3QxdPdwE1p00=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "3b9653a107c736222b5ae0d4036dd3b885219065",
+        "rev": "c43246d4e9e506178b69baed075d797ec2d873e2",
         "type": "github"
       },
       "original": {
@@ -448,11 +448,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1775490113,
-        "narHash": "sha256-2ZBhDNZZwYkRmefK5XLOusCJHnoeKkoN95hoSGgMxWM=",
+        "lastModified": 1776830795,
+        "narHash": "sha256-PAfvLwuHc1VOvsLcpk6+HDKgMEibvZjCNvbM1BJOA7o=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c775c2772ba56e906cbeb4e0b2db19079ef11ff7",
+        "rev": "72674a6b5599e844c045ae7449ba91f803d44ebc",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs-stable-25-11": {
       "locked": {
-        "lastModified": 1776434932,
-        "narHash": "sha256-gyqXNMgk3sh+ogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk=",
+        "lastModified": 1776560675,
+        "narHash": "sha256-p68udKWWh7+V4ZPpcMDq0gTHWNZJnr4JPI+kHPPE40o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c7f47036d3df2add644c46d712d14262b7d86c0c",
+        "rev": "e07580dae39738e46609eaab8b154de2488133ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'git-hooks-nix':
    'github:cachix/git-hooks.nix/580633fa3fe5fc0379905986543fd7495481913d?narHash=sha256-8Psjt%2BTWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4%3D' (2026-04-07)
  → 'github:cachix/git-hooks.nix/3cfd774b0a530725a077e17354fbdb87ea1c4aad?narHash=sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8%3D' (2026-04-21)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c555a4a34a260493be5adb795c54e013c58f2d34?narHash=sha256-zGuW7C4tsScib2560yE5VV6lY/MdRs30aU9cbg3RP%2BU%3D' (2026-04-20)
  → 'github:nix-community/home-manager/5d5640599a0050b994330328b9fd45709c909720?narHash=sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8%3D' (2026-04-21)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/18875f5fc1e2553ef80fb5c582efb003c687d241?narHash=sha256-/ztLPP7c1eZpTVLiWZ8WU8Tr17bfkGnl4PfUdGrL9mg%3D' (2026-04-21)
  → 'github:homebrew/homebrew-cask/32f12c76fa73da5142708eb9fdabeaea75ab88e3?narHash=sha256-AXWzCRMLMrjHAm7PxGqiHbFbm0p54Y4YUkxbJxMaG9M%3D' (2026-04-22)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/ba02c9d346bc890ec2f9d1516863bc6d5ce2955f?narHash=sha256-idNvaZVKELz6dV6sC%2BSO02aigMz7EHlbCTLQSleAvpY%3D' (2026-04-21)
  → 'github:homebrew/homebrew-core/bcac962a0cb666729b9aac358307c607808883bb?narHash=sha256-4NeqnM4JKnmw3ow0ec0TBTBYFbXbVdvtpqTj%2BC0sqEs%3D' (2026-04-22)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/3b9653a107c736222b5ae0d4036dd3b885219065?narHash=sha256-28Gqz0GDpGsBv8GtAn2dywEQRr%2BCtTDsD5J7VD6icBE%3D' (2026-04-19)
  → 'github:nix-community/nix-index-database/c43246d4e9e506178b69baed075d797ec2d873e2?narHash=sha256-oHVcvP2Ahhj1KUsEzp%2B2BQF55/r5VSa3QxdPdwE1p00%3D' (2026-04-22)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/c775c2772ba56e906cbeb4e0b2db19079ef11ff7?narHash=sha256-2ZBhDNZZwYkRmefK5XLOusCJHnoeKkoN95hoSGgMxWM%3D' (2026-04-06)
  → 'github:NixOS/nixos-hardware/72674a6b5599e844c045ae7449ba91f803d44ebc?narHash=sha256-PAfvLwuHc1VOvsLcpk6%2BHDKgMEibvZjCNvbM1BJOA7o%3D' (2026-04-22)
• Updated input 'nixpkgs-stable-25-11':
    'github:nixos/nixpkgs/c7f47036d3df2add644c46d712d14262b7d86c0c?narHash=sha256-gyqXNMgk3sh%2BogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk%3D' (2026-04-17)
  → 'github:nixos/nixpkgs/e07580dae39738e46609eaab8b154de2488133ce?narHash=sha256-p68udKWWh7%2BV4ZPpcMDq0gTHWNZJnr4JPI%2BkHPPE40o%3D' (2026-04-19)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'