### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776777932,
-        "narHash": "sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8=",
+        "lastModified": 1776904464,
+        "narHash": "sha256-sBUCj7/4d3Hoevpu3oQp8ccJNA1EDeVmFi1F8O6VJro=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d5640599a0050b994330328b9fd45709c909720",
+        "rev": "667b3c47325441e6a444faaf405bba76ec70338a",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776839947,
-        "narHash": "sha256-AXWzCRMLMrjHAm7PxGqiHbFbm0p54Y4YUkxbJxMaG9M=",
+        "lastModified": 1776923051,
+        "narHash": "sha256-e/Jsdd3Z6agcWpJGbzkEuvvWc0AxQ87opx3ObLZRXRk=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "32f12c76fa73da5142708eb9fdabeaea75ab88e3",
+        "rev": "1fd02bcf583573f56904cbd75c64edb79b57de67",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776840796,
-        "narHash": "sha256-4NeqnM4JKnmw3ow0ec0TBTBYFbXbVdvtpqTj+C0sqEs=",
+        "lastModified": 1776926593,
+        "narHash": "sha256-tMd94+ocG3E4SpLyzn2RaVdyHhiXw7FJunoXMN2pJLs=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "bcac962a0cb666729b9aac358307c607808883bb",
+        "rev": "1b3900a35d0ddd19fc4521683e2344af33dffff0",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs-stable-25-11": {
       "locked": {
-        "lastModified": 1776560675,
-        "narHash": "sha256-p68udKWWh7+V4ZPpcMDq0gTHWNZJnr4JPI+kHPPE40o=",
+        "lastModified": 1776734388,
+        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e07580dae39738e46609eaab8b154de2488133ce",
+        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/5d5640599a0050b994330328b9fd45709c909720?narHash=sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8%3D' (2026-04-21)
  → 'github:nix-community/home-manager/667b3c47325441e6a444faaf405bba76ec70338a?narHash=sha256-sBUCj7/4d3Hoevpu3oQp8ccJNA1EDeVmFi1F8O6VJro%3D' (2026-04-23)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/32f12c76fa73da5142708eb9fdabeaea75ab88e3?narHash=sha256-AXWzCRMLMrjHAm7PxGqiHbFbm0p54Y4YUkxbJxMaG9M%3D' (2026-04-22)
  → 'github:homebrew/homebrew-cask/1fd02bcf583573f56904cbd75c64edb79b57de67?narHash=sha256-e/Jsdd3Z6agcWpJGbzkEuvvWc0AxQ87opx3ObLZRXRk%3D' (2026-04-23)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/bcac962a0cb666729b9aac358307c607808883bb?narHash=sha256-4NeqnM4JKnmw3ow0ec0TBTBYFbXbVdvtpqTj%2BC0sqEs%3D' (2026-04-22)
  → 'github:homebrew/homebrew-core/1b3900a35d0ddd19fc4521683e2344af33dffff0?narHash=sha256-tMd94%2BocG3E4SpLyzn2RaVdyHhiXw7FJunoXMN2pJLs%3D' (2026-04-23)
• Updated input 'nixpkgs-stable-25-11':
    'github:nixos/nixpkgs/e07580dae39738e46609eaab8b154de2488133ce?narHash=sha256-p68udKWWh7%2BV4ZPpcMDq0gTHWNZJnr4JPI%2BkHPPE40o%3D' (2026-04-19)
  → 'github:nixos/nixpkgs/10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac?narHash=sha256-vl3dkhlE5gzsItuHoEMVe%2BDlonsK%2B0836LIRDnm6MXQ%3D' (2026-04-21)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'