### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -73,16 +73,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1774235677,
-        "narHash": "sha256-0ryNYmzDAeRlrzPTAgmzGH/Cgc8iv/LBN6jWGUANvIk=",
+        "lastModified": 1776478798,
+        "narHash": "sha256-ERStG27tf83VbCfYMxtDSs+sa8FUMJ/3jSu/QfX9rKE=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "894a3d23ac0c8aaf561b9874b528b9cb2e839201",
+        "rev": "3aae056b8d072624255bc8fd27febb7f327b2265",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.1",
+        "ref": "5.1.7",
         "repo": "brew",
         "type": "github"
       }
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1777678872,
+        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777004352,
-        "narHash": "sha256-SV+9PgNwZ8jHVCjK6YaCBzaheLSW7cDnm5DpOYrD8Vw=",
+        "lastModified": 1777679572,
+        "narHash": "sha256-egYNbRrkn+6SwTHinhdb6WUfzzdC3nXfCRqS321VylY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6012cf1fed3eba66115f3fd117b9be6bd2a15b2f",
+        "rev": "9cb587ade2aa1b4a7257f0238d41072690b0ca4f",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1777011261,
-        "narHash": "sha256-tOlmHYhWtsKSZW+5JsbD/LgfFE9ESuc8HCv6CvJdXl4=",
+        "lastModified": 1777704307,
+        "narHash": "sha256-I+HccQ/SbA+ApU3VtDeSRvEAQj/pqceyOm3Q3C6+euc=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "7d3ded4c89f88d92ee585b6ac4a9d62ba1df84af",
+        "rev": "33be33616c31f87f25e4defe0c74f9d49e0a28f7",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1777008261,
-        "narHash": "sha256-r3LLq58AW/yqByEG00ngQ0KRHw3z89BzIZXC97q7HeU=",
+        "lastModified": 1777702839,
+        "narHash": "sha256-Z4FOsWNESbamndj82Wv64LiE30O8o0SU+mr9PpRt1qI=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "936d379bad5c8bbd8c6ffca68523a7517fdba113",
+        "rev": "8121d548bea9f529cb8209bbe8fe855389751104",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1774720267,
-        "narHash": "sha256-YYftFe8jyfpQI649yfr0E+dqEXE2jznZNcYvy/lKV1U=",
+        "lastModified": 1777250621,
+        "narHash": "sha256-WynkkG0hdZ5niYPJUbVg7oMfu8MVwGGzKZ6lKmfa+O8=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "a7760a3a83f7609f742861afb5732210fdc437ed",
+        "rev": "aeb2069920742d0d6570089e8b3b8620050bacf2",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776829403,
-        "narHash": "sha256-oHVcvP2Ahhj1KUsEzp+2BQF55/r5VSa3QxdPdwE1p00=",
+        "lastModified": 1777181277,
+        "narHash": "sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "c43246d4e9e506178b69baed075d797ec2d873e2",
+        "rev": "b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs-stable-25-11": {
       "locked": {
-        "lastModified": 1776734388,
-        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b?narHash=sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA%3D' (2026-04-01)
  → 'github:hercules-ci/flake-parts/5250617bffd85403b14dbf43c3870e7f255d2c16?narHash=sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT%2BIPhcsukVbgk%3D' (2026-05-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/6012cf1fed3eba66115f3fd117b9be6bd2a15b2f?narHash=sha256-SV%2B9PgNwZ8jHVCjK6YaCBzaheLSW7cDnm5DpOYrD8Vw%3D' (2026-04-24)
  → 'github:nix-community/home-manager/9cb587ade2aa1b4a7257f0238d41072690b0ca4f?narHash=sha256-egYNbRrkn%2B6SwTHinhdb6WUfzzdC3nXfCRqS321VylY%3D' (2026-05-01)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/7d3ded4c89f88d92ee585b6ac4a9d62ba1df84af?narHash=sha256-tOlmHYhWtsKSZW%2B5JsbD/LgfFE9ESuc8HCv6CvJdXl4%3D' (2026-04-24)
  → 'github:homebrew/homebrew-cask/33be33616c31f87f25e4defe0c74f9d49e0a28f7?narHash=sha256-I%2BHccQ/SbA%2BApU3VtDeSRvEAQj/pqceyOm3Q3C6%2Beuc%3D' (2026-05-02)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/936d379bad5c8bbd8c6ffca68523a7517fdba113?narHash=sha256-r3LLq58AW/yqByEG00ngQ0KRHw3z89BzIZXC97q7HeU%3D' (2026-04-24)
  → 'github:homebrew/homebrew-core/8121d548bea9f529cb8209bbe8fe855389751104?narHash=sha256-Z4FOsWNESbamndj82Wv64LiE30O8o0SU%2Bmr9PpRt1qI%3D' (2026-05-02)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/a7760a3a83f7609f742861afb5732210fdc437ed?narHash=sha256-YYftFe8jyfpQI649yfr0E%2BdqEXE2jznZNcYvy/lKV1U%3D' (2026-03-28)
  → 'github:zhaofengli/nix-homebrew/aeb2069920742d0d6570089e8b3b8620050bacf2?narHash=sha256-WynkkG0hdZ5niYPJUbVg7oMfu8MVwGGzKZ6lKmfa%2BO8%3D' (2026-04-27)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/894a3d23ac0c8aaf561b9874b528b9cb2e839201?narHash=sha256-0ryNYmzDAeRlrzPTAgmzGH/Cgc8iv/LBN6jWGUANvIk%3D' (2026-03-23)
  → 'github:Homebrew/brew/3aae056b8d072624255bc8fd27febb7f327b2265?narHash=sha256-ERStG27tf83VbCfYMxtDSs%2Bsa8FUMJ/3jSu/QfX9rKE%3D' (2026-04-18)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/c43246d4e9e506178b69baed075d797ec2d873e2?narHash=sha256-oHVcvP2Ahhj1KUsEzp%2B2BQF55/r5VSa3QxdPdwE1p00%3D' (2026-04-22)
  → 'github:nix-community/nix-index-database/b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa?narHash=sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8%3D' (2026-04-26)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/b12141ef619e0a9c1c84dc8c684040326f27cdcc?narHash=sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24%3D' (2026-04-18)
  → 'github:NixOS/nixpkgs/15f4ee454b1dce334612fa6843b3e05cf546efab?narHash=sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM%2BZ4%3D' (2026-04-30)
• Updated input 'nixpkgs-stable-25-11':
    'github:nixos/nixpkgs/10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac?narHash=sha256-vl3dkhlE5gzsItuHoEMVe%2BDlonsK%2B0836LIRDnm6MXQ%3D' (2026-04-21)
  → 'github:nixos/nixpkgs/755f5aa91337890c432639c60b6064bb7fe67769?narHash=sha256-ypxFOeDz%2BCqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI%3D' (2026-04-29)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'