### PR TITLE
feat(glyph): add vault to restic backup paths

### DIFF
--- a/hosts/glyph/services/default.nix
+++ b/hosts/glyph/services/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  lib,
   pkgs,
   ...
 }: {
@@ -109,12 +110,14 @@
   services.basic-memory.enable = true;
   rc.backup = {
     enable = true;
-    paths = [
-      config.services.postgresqlBackup.location
-      "/var/lib/basic-memory"
-      "/var/lib/open-webui"
-      "/var/lib/roon-server/backup"
-    ];
+    paths =
+      [
+        config.services.postgresqlBackup.location
+        "/var/lib/basic-memory"
+        "/var/lib/open-webui"
+        "/var/lib/roon-server/backup"
+      ]
+      ++ lib.optional config.rc.obsidian-sync.enable config.rc.obsidian-sync.vaultPath;
   };
   services.mcp-nixos.enable = true;
   services.kagi-mcp = {


### PR DESCRIPTION
## Summary

- Adds `config.rc.obsidian-sync.vaultPath` to the existing restic backup paths on glyph
- References the option directly so it stays in sync if the path is ever changed

## Test / verify

- After deploying, confirm `systemctl status restic-backups-daily` runs cleanly
- Check the R2 bucket includes vault contents in the next snapshot