### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776613567,
-        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
+        "lastModified": 1777713215,
+        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
+        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777679572,
-        "narHash": "sha256-egYNbRrkn+6SwTHinhdb6WUfzzdC3nXfCRqS321VylY=",
+        "lastModified": 1777780644,
+        "narHash": "sha256-CYpc+mk28rmcQWGygeM8CA+Z8SZYy8BOyQtiW18spao=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9cb587ade2aa1b4a7257f0238d41072690b0ca4f",
+        "rev": "b9311028044a9e9b2cf27db15ef0a87d464e212d",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1777704307,
-        "narHash": "sha256-I+HccQ/SbA+ApU3VtDeSRvEAQj/pqceyOm3Q3C6+euc=",
+        "lastModified": 1777792332,
+        "narHash": "sha256-CaOHAl8Nztg0aCBe19D11DVGBy6tPWfmG7v49noz0Kg=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "33be33616c31f87f25e4defe0c74f9d49e0a28f7",
+        "rev": "6f30552878f238317783b55aec5ee8d91cb1479a",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1777702839,
-        "narHash": "sha256-Z4FOsWNESbamndj82Wv64LiE30O8o0SU+mr9PpRt1qI=",
+        "lastModified": 1777787613,
+        "narHash": "sha256-WYq+TUF+ydrqQDGcWEkbRgaLP1Sk8g4jlqWW8InkWTM=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "8121d548bea9f529cb8209bbe8fe855389751104",
+        "rev": "01da81fbeaf046dbdaca42f7a2a807e357297099",
         "type": "github"
       },
       "original": {
@@ -374,11 +374,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775037210,
-        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
+        "lastModified": 1777780666,
+        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
+        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777181277,
-        "narHash": "sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8=",
+        "lastModified": 1777787189,
+        "narHash": "sha256-2KUbS/HhzWW3kkkY1+RiWj9mJ76VEXw8lBJzcCFKzfY=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa",
+        "rev": "2dea2b920e7127b3afa8506713f23536651de312",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/32f4236bfc141ae930b5ba2fb604f561fed5219d?narHash=sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI%3D' (2026-04-19)
  → 'github:nix-community/disko/63b4e7e6cf75307c1d26ac3762b886b5b0247267?narHash=sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo%3D' (2026-05-02)
• Updated input 'home-manager':
    'github:nix-community/home-manager/9cb587ade2aa1b4a7257f0238d41072690b0ca4f?narHash=sha256-egYNbRrkn%2B6SwTHinhdb6WUfzzdC3nXfCRqS321VylY%3D' (2026-05-01)
  → 'github:nix-community/home-manager/b9311028044a9e9b2cf27db15ef0a87d464e212d?narHash=sha256-CYpc%2Bmk28rmcQWGygeM8CA%2BZ8SZYy8BOyQtiW18spao%3D' (2026-05-03)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/33be33616c31f87f25e4defe0c74f9d49e0a28f7?narHash=sha256-I%2BHccQ/SbA%2BApU3VtDeSRvEAQj/pqceyOm3Q3C6%2Beuc%3D' (2026-05-02)
  → 'github:homebrew/homebrew-cask/6f30552878f238317783b55aec5ee8d91cb1479a?narHash=sha256-CaOHAl8Nztg0aCBe19D11DVGBy6tPWfmG7v49noz0Kg%3D' (2026-05-03)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/8121d548bea9f529cb8209bbe8fe855389751104?narHash=sha256-Z4FOsWNESbamndj82Wv64LiE30O8o0SU%2Bmr9PpRt1qI%3D' (2026-05-02)
  → 'github:homebrew/homebrew-core/01da81fbeaf046dbdaca42f7a2a807e357297099?narHash=sha256-WYq%2BTUF%2BydrqQDGcWEkbRgaLP1Sk8g4jlqWW8InkWTM%3D' (2026-05-03)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/06648f4902343228ce2de79f291dd5a58ee12146?narHash=sha256-KM2WYj6EA7M/FVZVCl3rqWY%2BTFV5QzSyyGE2gQxeODU%3D' (2026-04-01)
  → 'github:LnL7/nix-darwin/8c62fba0854ba15c8917aed18894dbccb48a3777?narHash=sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE%3D' (2026-05-03)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/b8eb7acee0f7604fe1bf6a5b3dcf5254369180fa?narHash=sha256-yVJbd07ortDRAttDFmDV5p220aOLTHgVAx//0nW/xW8%3D' (2026-04-26)
  → 'github:nix-community/nix-index-database/2dea2b920e7127b3afa8506713f23536651de312?narHash=sha256-2KUbS/HhzWW3kkkY1%2BRiWj9mJ76VEXw8lBJzcCFKzfY%3D' (2026-05-03)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'