### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780644,
-        "narHash": "sha256-CYpc+mk28rmcQWGygeM8CA+Z8SZYy8BOyQtiW18spao=",
+        "lastModified": 1777852249,
+        "narHash": "sha256-XdbGWnFlX4McOEG5NioVsp35Ic6XL/rXnp8as71cu6o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b9311028044a9e9b2cf27db15ef0a87d464e212d",
+        "rev": "c909892de502b4de9e92838a503c09a9c8ebe4aa",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1777792332,
-        "narHash": "sha256-CaOHAl8Nztg0aCBe19D11DVGBy6tPWfmG7v49noz0Kg=",
+        "lastModified": 1777880841,
+        "narHash": "sha256-zugK7PN0Vis6plAG8Tc5h7V1GMGqohx3caJ/ZFVcwkE=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "6f30552878f238317783b55aec5ee8d91cb1479a",
+        "rev": "531c1c78d02b724d2e2d534ae9307d2b8e079f7b",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1777787613,
-        "narHash": "sha256-WYq+TUF+ydrqQDGcWEkbRgaLP1Sk8g4jlqWW8InkWTM=",
+        "lastModified": 1777878244,
+        "narHash": "sha256-HdFNFgVdZnb7wb2eKTfyjPaYqhfrEg8wPe9tgW49aLU=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "01da81fbeaf046dbdaca42f7a2a807e357297099",
+        "rev": "63b9d7da4ccd57d76b6583b880701b0c078861e0",
         "type": "github"
       },
       "original": {
@@ -448,11 +448,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1776983936,
-        "narHash": "sha256-ZOQyNqSvJ8UdrrqU1p7vaFcdL53idK+LOM8oRWEWh6o=",
+        "lastModified": 1777796046,
+        "narHash": "sha256-bEJp/zaQApzynGRaAO62BZSz9tFikKtIHCn2yIA/s7Q=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2096f3f411ce46e88a79ae4eafcfc9df8ed41c61",
+        "rev": "eeb02f6e29fc8139c0b15af5ff0fdfdc6d0d3d90",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs-stable-25-11": {
       "locked": {
-        "lastModified": 1777428379,
-        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "lastModified": 1777673416,
+        "narHash": "sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "rev": "26ef669cffa904b6f6832ab57b77892a37c1a671",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/b9311028044a9e9b2cf27db15ef0a87d464e212d?narHash=sha256-CYpc%2Bmk28rmcQWGygeM8CA%2BZ8SZYy8BOyQtiW18spao%3D' (2026-05-03)
  → 'github:nix-community/home-manager/c909892de502b4de9e92838a503c09a9c8ebe4aa?narHash=sha256-XdbGWnFlX4McOEG5NioVsp35Ic6XL/rXnp8as71cu6o%3D' (2026-05-03)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/6f30552878f238317783b55aec5ee8d91cb1479a?narHash=sha256-CaOHAl8Nztg0aCBe19D11DVGBy6tPWfmG7v49noz0Kg%3D' (2026-05-03)
  → 'github:homebrew/homebrew-cask/531c1c78d02b724d2e2d534ae9307d2b8e079f7b?narHash=sha256-zugK7PN0Vis6plAG8Tc5h7V1GMGqohx3caJ/ZFVcwkE%3D' (2026-05-04)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/01da81fbeaf046dbdaca42f7a2a807e357297099?narHash=sha256-WYq%2BTUF%2BydrqQDGcWEkbRgaLP1Sk8g4jlqWW8InkWTM%3D' (2026-05-03)
  → 'github:homebrew/homebrew-core/63b9d7da4ccd57d76b6583b880701b0c078861e0?narHash=sha256-HdFNFgVdZnb7wb2eKTfyjPaYqhfrEg8wPe9tgW49aLU%3D' (2026-05-04)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/2096f3f411ce46e88a79ae4eafcfc9df8ed41c61?narHash=sha256-ZOQyNqSvJ8UdrrqU1p7vaFcdL53idK%2BLOM8oRWEWh6o%3D' (2026-04-23)
  → 'github:NixOS/nixos-hardware/eeb02f6e29fc8139c0b15af5ff0fdfdc6d0d3d90?narHash=sha256-bEJp/zaQApzynGRaAO62BZSz9tFikKtIHCn2yIA/s7Q%3D' (2026-05-03)
• Updated input 'nixpkgs-stable-25-11':
    'github:nixos/nixpkgs/755f5aa91337890c432639c60b6064bb7fe67769?narHash=sha256-ypxFOeDz%2BCqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI%3D' (2026-04-29)
  → 'github:nixos/nixpkgs/26ef669cffa904b6f6832ab57b77892a37c1a671?narHash=sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs%3D' (2026-05-01)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'