### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -509,22 +509,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable-25-11": {
-      "locked": {
-        "lastModified": 1779102034,
-        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "agenix": "agenix",
@@ -544,7 +528,6 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
         "nixpkgs-stable-24-05": "nixpkgs-stable-24-05",
-        "nixpkgs-stable-25-11": "nixpkgs-stable-25-11",
         "systems": "systems_2",
         "zx-dev": "zx-dev"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -73,16 +73,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1776478798,
-        "narHash": "sha256-ERStG27tf83VbCfYMxtDSs+sa8FUMJ/3jSu/QfX9rKE=",
+        "lastModified": 1778427648,
+        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "3aae056b8d072624255bc8fd27febb7f327b2265",
+        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.7",
+        "ref": "5.1.11",
         "repo": "brew",
         "type": "github"
       }
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777713215,
-        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
+        "lastModified": 1779226674,
+        "narHash": "sha256-wuOkjI6pRiN4sEn/EPBRnNW5cmcpvd7xtIM8y5LooAs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
+        "rev": "65fb947964bd44fc0008faf77d1fcb7a9f40bb32",
         "type": "github"
       },
       "original": {
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777678872,
-        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -286,11 +286,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775592125,
-        "narHash": "sha256-6kVGyNf5X7H7h/Vf8ge18YQPxRzljTlwPRpLdIPjndY=",
+        "lastModified": 1777992933,
+        "narHash": "sha256-b+eN1E5PAQVexQ9+uDxdGrM5aGsz9hpUNuircAb0bmo=",
         "owner": "tailscale",
         "repo": "golink",
-        "rev": "0c619de1671d3d8c8157ec2584115cdac41cc501",
+        "rev": "b85eec3e0ed734380a61b31782b72818f214c494",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777852249,
-        "narHash": "sha256-XdbGWnFlX4McOEG5NioVsp35Ic6XL/rXnp8as71cu6o=",
+        "lastModified": 1779336838,
+        "narHash": "sha256-n1+l78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q+d8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c909892de502b4de9e92838a503c09a9c8ebe4aa",
+        "rev": "928d72376949e222ea4f07b44828a55b0136422e",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1777880841,
-        "narHash": "sha256-zugK7PN0Vis6plAG8Tc5h7V1GMGqohx3caJ/ZFVcwkE=",
+        "lastModified": 1779351692,
+        "narHash": "sha256-bF7EkJpFPIT8+HNUUIDYt/anwPSchkOyfJ9VMwxU4E8=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "531c1c78d02b724d2e2d534ae9307d2b8e079f7b",
+        "rev": "320f0bac2d332d1bb9c20968687cf2ecb9c724cb",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1777878244,
-        "narHash": "sha256-HdFNFgVdZnb7wb2eKTfyjPaYqhfrEg8wPe9tgW49aLU=",
+        "lastModified": 1779350129,
+        "narHash": "sha256-R7PPIeYHh5JRPXlr3VOIxNmBsbm3oKlfaCgS1nxG+Fs=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "63b9d7da4ccd57d76b6583b880701b0c078861e0",
+        "rev": "be448263a0922cb194e7acc02308cb61eab7d959",
         "type": "github"
       },
       "original": {
@@ -374,11 +374,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780666,
-        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1777250621,
-        "narHash": "sha256-WynkkG0hdZ5niYPJUbVg7oMfu8MVwGGzKZ6lKmfa+O8=",
+        "lastModified": 1778851564,
+        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "aeb2069920742d0d6570089e8b3b8620050bacf2",
+        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777787189,
-        "narHash": "sha256-2KUbS/HhzWW3kkkY1+RiWj9mJ76VEXw8lBJzcCFKzfY=",
+        "lastModified": 1778999127,
+        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "2dea2b920e7127b3afa8506713f23536651de312",
+        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
         "type": "github"
       },
       "original": {
@@ -448,11 +448,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1777796046,
-        "narHash": "sha256-bEJp/zaQApzynGRaAO62BZSz9tFikKtIHCn2yIA/s7Q=",
+        "lastModified": 1779258371,
+        "narHash": "sha256-j1iZsLy6oFApqR1oiDmHhvkwxXqcNi0aoSJj643LuwU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "eeb02f6e29fc8139c0b15af5ff0fdfdc6d0d3d90",
+        "rev": "c97bc4d15bd3473dd095e8e8ba57330ab1943a77",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs-stable-25-11": {
       "locked": {
-        "lastModified": 1777673416,
-        "narHash": "sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs=",
+        "lastModified": 1779102034,
+        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "26ef669cffa904b6f6832ab57b77892a37c1a671",
+        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-stable-25-11.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-stable-24-05.url = "github:nixos/nixpkgs/nixos-24.05";
 
     # General

--- a/hosts/glyph/home.nix
+++ b/hosts/glyph/home.nix
@@ -2,7 +2,6 @@
   config,
   llm-profile,
   pkgs,
-  pkgs-stable-25-11,
   ...
 }: {
   home.packages = [pkgs.mktorrent pkgs.obsidian-headless];
@@ -32,7 +31,6 @@
 
   programs.beets = {
     enable = true;
-    package = pkgs-stable-25-11.beets;
     settings = {
       directory = "/mnt/media/Music";
       import = {

--- a/hosts/spore/services/web/irc-proxy.nix
+++ b/hosts/spore/services/web/irc-proxy.nix
@@ -23,7 +23,7 @@ in {
 
         # intermediate configuration
         ssl_protocols ${config.services.nginx.sslProtocols};
-        ssl_ciphers ${config.services.nginx.sslCiphers};
+        ssl_ciphers ${lib.concatStringsSep ":" config.services.nginx.sslCiphers};
         ssl_prefer_server_ciphers off;
 
         # Proxy stream
@@ -32,7 +32,7 @@ in {
         proxy_ssl_certificate ${certs.${certName}.directory}/fullchain.pem;
         proxy_ssl_certificate_key ${certs.${certName}.directory}/key.pem;
         proxy_ssl_protocols ${config.services.nginx.sslProtocols};
-        proxy_ssl_ciphers ${config.services.nginx.sslCiphers};
+        proxy_ssl_ciphers ${lib.concatStringsSep ":" config.services.nginx.sslCiphers};
         proxy_ssl_session_reuse on;
     }
   '';

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -1,7 +1,6 @@
 inputs @ {
   self,
   nixpkgs,
-  nixpkgs-stable-25-11,
   nixpkgs-stable-24-05,
   agenix,
   home-manager,
@@ -28,7 +27,6 @@ inputs @ {
     showBatteryStatus,
     lightweight ? false,
   }: let
-    pkgs-stable-25-11 = import nixpkgs-stable-25-11 {inherit system;};
     pkgs-stable-24-05 = import nixpkgs-stable-24-05 {inherit system;};
     hostHomePath = ./../hosts/${configDir}/home.nix;
     hostHomeConfig =
@@ -49,7 +47,7 @@ inputs @ {
         ++ nixpkgs.lib.optionals (hostHomeConfig != null) [hostHomeConfig];
     };
     home-manager.extraSpecialArgs = {
-      inherit hostname lightweight llm-profile pkgs-stable-25-11 pkgs-stable-24-05 showBatteryStatus;
+      inherit hostname lightweight llm-profile pkgs-stable-24-05 showBatteryStatus;
     };
   };
 
@@ -64,7 +62,6 @@ inputs @ {
       inherit system;
       specialArgs = {
         inherit inputs keys username hostname;
-        pkgs-stable-25-11 = import nixpkgs-stable-25-11 {inherit system;};
         pkgs-stable-24-05 = import nixpkgs-stable-24-05 {inherit system;};
       };
       modules = [
@@ -100,7 +97,6 @@ inputs @ {
       inherit system;
       specialArgs = {
         inherit inputs self keys username hostname;
-        pkgs-stable-25-11 = import nixpkgs-stable-25-11 {inherit system;};
         pkgs-stable-24-05 = import nixpkgs-stable-24-05 {inherit system;};
         nixDarwin = nix-darwin;
       };


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/63b4e7e6cf75307c1d26ac3762b886b5b0247267?narHash=sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo%3D' (2026-05-02)
  → 'github:nix-community/disko/65fb947964bd44fc0008faf77d1fcb7a9f40bb32?narHash=sha256-wuOkjI6pRiN4sEn/EPBRnNW5cmcpvd7xtIM8y5LooAs%3D' (2026-05-19)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/5250617bffd85403b14dbf43c3870e7f255d2c16?narHash=sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT%2BIPhcsukVbgk%3D' (2026-05-01)
  → 'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
• Updated input 'git-hooks-nix':
    'github:cachix/git-hooks.nix/3cfd774b0a530725a077e17354fbdb87ea1c4aad?narHash=sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8%3D' (2026-04-21)
  → 'github:cachix/git-hooks.nix/61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a?narHash=sha256-kTwur1wV%2B01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs%3D' (2026-05-11)
• Updated input 'golink':
    'github:tailscale/golink/0c619de1671d3d8c8157ec2584115cdac41cc501?narHash=sha256-6kVGyNf5X7H7h/Vf8ge18YQPxRzljTlwPRpLdIPjndY%3D' (2026-04-07)
  → 'github:tailscale/golink/b85eec3e0ed734380a61b31782b72818f214c494?narHash=sha256-b%2BeN1E5PAQVexQ9%2BuDxdGrM5aGsz9hpUNuircAb0bmo%3D' (2026-05-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c909892de502b4de9e92838a503c09a9c8ebe4aa?narHash=sha256-XdbGWnFlX4McOEG5NioVsp35Ic6XL/rXnp8as71cu6o%3D' (2026-05-03)
  → 'github:nix-community/home-manager/928d72376949e222ea4f07b44828a55b0136422e?narHash=sha256-n1%2Bl78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q%2Bd8%3D' (2026-05-21)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/531c1c78d02b724d2e2d534ae9307d2b8e079f7b?narHash=sha256-zugK7PN0Vis6plAG8Tc5h7V1GMGqohx3caJ/ZFVcwkE%3D' (2026-05-04)
  → 'github:homebrew/homebrew-cask/320f0bac2d332d1bb9c20968687cf2ecb9c724cb?narHash=sha256-bF7EkJpFPIT8%2BHNUUIDYt/anwPSchkOyfJ9VMwxU4E8%3D' (2026-05-21)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/63b9d7da4ccd57d76b6583b880701b0c078861e0?narHash=sha256-HdFNFgVdZnb7wb2eKTfyjPaYqhfrEg8wPe9tgW49aLU%3D' (2026-05-04)
  → 'github:homebrew/homebrew-core/be448263a0922cb194e7acc02308cb61eab7d959?narHash=sha256-R7PPIeYHh5JRPXlr3VOIxNmBsbm3oKlfaCgS1nxG%2BFs%3D' (2026-05-21)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/8c62fba0854ba15c8917aed18894dbccb48a3777?narHash=sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE%3D' (2026-05-03)
  → 'github:LnL7/nix-darwin/56c666e108467d87d13508936aade6d567f2a501?narHash=sha256-zXcwYQGCT6pzinK%2B1dBB2ekTVtfxGZAapb3Evdcu4fY%3D' (2026-05-17)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/aeb2069920742d0d6570089e8b3b8620050bacf2?narHash=sha256-WynkkG0hdZ5niYPJUbVg7oMfu8MVwGGzKZ6lKmfa%2BO8%3D' (2026-04-27)
  → 'github:zhaofengli/nix-homebrew/b3a87b4793205cc111f3c61e25e018ffac3b8039?narHash=sha256-p8wzcnpB2Iys%2BQzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE%3D' (2026-05-15)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/3aae056b8d072624255bc8fd27febb7f327b2265?narHash=sha256-ERStG27tf83VbCfYMxtDSs%2Bsa8FUMJ/3jSu/QfX9rKE%3D' (2026-04-18)
  → 'github:Homebrew/brew/6f293daa9f9f5832e13b497976335e90509886d7?narHash=sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE%3D' (2026-05-10)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/2dea2b920e7127b3afa8506713f23536651de312?narHash=sha256-2KUbS/HhzWW3kkkY1%2BRiWj9mJ76VEXw8lBJzcCFKzfY%3D' (2026-05-03)
  → 'github:nix-community/nix-index-database/f680e0d3c1dbefe298c423691662e238496890f2?narHash=sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg%3D' (2026-05-17)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/eeb02f6e29fc8139c0b15af5ff0fdfdc6d0d3d90?narHash=sha256-bEJp/zaQApzynGRaAO62BZSz9tFikKtIHCn2yIA/s7Q%3D' (2026-05-03)
  → 'github:NixOS/nixos-hardware/c97bc4d15bd3473dd095e8e8ba57330ab1943a77?narHash=sha256-j1iZsLy6oFApqR1oiDmHhvkwxXqcNi0aoSJj643LuwU%3D' (2026-05-20)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/15f4ee454b1dce334612fa6843b3e05cf546efab?narHash=sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM%2BZ4%3D' (2026-04-30)
  → 'github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb?narHash=sha256-30sZNZoA1cqF5JNO9fVX%2BwgiQYjB7HJqqJ4ztCDeBZE%3D' (2026-05-15)
• Updated input 'nixpkgs-stable-25-11':
    'github:nixos/nixpkgs/26ef669cffa904b6f6832ab57b77892a37c1a671?narHash=sha256-5c2POKPOjU40Kh0MirOdScBLG0bu9TAuPYAtPRNZMBs%3D' (2026-05-01)
  → 'github:nixos/nixpkgs/687f05a9184cad4eaf905c48b63649e3a86f5433?narHash=sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg%3D' (2026-05-18)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'