### PR TITLE
feat(lobtop): add launchd agent for Warp/Tailscale conflict fix

### DIFF
--- a/hosts/lobtop/home.nix
+++ b/hosts/lobtop/home.nix
@@ -1,3 +1,52 @@
-{pkgs, ...}: {
+{pkgs, ...}: let
+  restoreScript = pkgs.writeShellScript "restore-warp-tailscale" ''
+    WARP=/usr/local/bin/warp-cli
+
+    IP_RANGES=("100.64.0.0/10")
+    DNS_DOMAINS=("ts.net" "ts.zx.dev")
+
+    log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+
+    apply_ip_ranges() {
+      local existing
+      existing=$("$WARP" tunnel ip list 2>/dev/null)
+      for range in "''${IP_RANGES[@]}"; do
+        if echo "$existing" | grep -qF "$range"; then
+          log "IP range already present: $range"
+        else
+          "$WARP" tunnel ip add-range "$range" 2>/dev/null && log "Added IP range: $range"
+        fi
+      done
+    }
+
+    apply_dns_fallbacks() {
+      local existing
+      existing=$("$WARP" dns fallback list 2>/dev/null)
+      for domain in "''${DNS_DOMAINS[@]}"; do
+        if echo "$existing" | grep -qF "$domain"; then
+          log "DNS fallback already present: $domain"
+        else
+          "$WARP" dns fallback add "$domain" 2>/dev/null && log "Added DNS fallback: $domain"
+        fi
+      done
+    }
+
+    log "Starting WARP/Tailscale restore"
+    apply_ip_ranges
+    apply_dns_fallbacks
+    log "Done"
+  '';
+in {
   rc.gpg.enable = true;
+
+  launchd.agents."com.user.restore-warp-tailscale" = {
+    enable = true;
+    config = {
+      ProgramArguments = ["${restoreScript}"];
+      WatchPaths = ["/Applications/Cloudflare WARP.app/Contents/Resources"];
+      RunAtLoad = true;
+      StandardOutPath = "/tmp/restore-warp-tailscale.log";
+      StandardErrorPath = "/tmp/restore-warp-tailscale.log";
+    };
+  };
 }


### PR DESCRIPTION
## Summary

- Adds a home-manager `launchd.agents` user agent to `hosts/lobtop/home.nix`
- The agent runs `restore-warp-tailscale` at login (`RunAtLoad`) and whenever Cloudflare WARP updates its app bundle (`WatchPaths`)
- Configures split-tunnel exclusion for `100.64.0.0/10` and DNS fallback domains `ts.net` / `ts.zx.dev` to resolve Tailscale conflicts with WARP

## Test plan

- [ ] `nh darwin switch .#lobtop` on lobtop
- [ ] `launchctl list | grep restore-warp-tailscale` — confirm agent is loaded
- [ ] `cat /tmp/restore-warp-tailscale.log` — confirm script ran successfully
- [ ] `warp-cli tunnel ip list` — confirm `100.64.0.0/10` is present
- [ ] `warp-cli dns fallback list` — confirm `ts.net` and `ts.zx.dev` are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)