### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1779351692,
-        "narHash": "sha256-bF7EkJpFPIT8+HNUUIDYt/anwPSchkOyfJ9VMwxU4E8=",
+        "lastModified": 1779434598,
+        "narHash": "sha256-DGIvqkjbokN82rABjzybxMYxAC2FFmz6iOVHfntxw0A=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "320f0bac2d332d1bb9c20968687cf2ecb9c724cb",
+        "rev": "264f531e8a27cdefdbcfdd358d5ff7f5b372ffea",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1779350129,
-        "narHash": "sha256-R7PPIeYHh5JRPXlr3VOIxNmBsbm3oKlfaCgS1nxG+Fs=",
+        "lastModified": 1779421688,
+        "narHash": "sha256-X55w6Q+lsTNz3xkzY5+qZK3T5kvkIX1/rA6kE4HF4W8=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "be448263a0922cb194e7acc02308cb61eab7d959",
+        "rev": "a275516112bbff26ff5c4d6a99fcf261290ade70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/320f0bac2d332d1bb9c20968687cf2ecb9c724cb?narHash=sha256-bF7EkJpFPIT8%2BHNUUIDYt/anwPSchkOyfJ9VMwxU4E8%3D' (2026-05-21)
  → 'github:homebrew/homebrew-cask/264f531e8a27cdefdbcfdd358d5ff7f5b372ffea?narHash=sha256-DGIvqkjbokN82rABjzybxMYxAC2FFmz6iOVHfntxw0A%3D' (2026-05-22)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/be448263a0922cb194e7acc02308cb61eab7d959?narHash=sha256-R7PPIeYHh5JRPXlr3VOIxNmBsbm3oKlfaCgS1nxG%2BFs%3D' (2026-05-21)
  → 'github:homebrew/homebrew-core/a275516112bbff26ff5c4d6a99fcf261290ade70?narHash=sha256-X55w6Q%2BlsTNz3xkzY5%2BqZK3T5kvkIX1/rA6kE4HF4W8%3D' (2026-05-22)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'