### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779226674,
-        "narHash": "sha256-wuOkjI6pRiN4sEn/EPBRnNW5cmcpvd7xtIM8y5LooAs=",
+        "lastModified": 1779699611,
+        "narHash": "sha256-EcCaSTKnmg2o4wLKaN1aqQFomwyhO7ik0bX9COdyCas=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "65fb947964bd44fc0008faf77d1fcb7a9f40bb32",
+        "rev": "5ba0c9555c28685e57fa54c7a25e42c7efdbfc8d",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779336838,
-        "narHash": "sha256-n1+l78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q+d8=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "928d72376949e222ea4f07b44828a55b0136422e",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1779434598,
-        "narHash": "sha256-DGIvqkjbokN82rABjzybxMYxAC2FFmz6iOVHfntxw0A=",
+        "lastModified": 1779783704,
+        "narHash": "sha256-HITU46GJUHS34Bzybu2Jh3w8B/41GI8cpb162usuIlw=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "264f531e8a27cdefdbcfdd358d5ff7f5b372ffea",
+        "rev": "715791512131cd20e1819356ef2b3b840ff46177",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1779421688,
-        "narHash": "sha256-X55w6Q+lsTNz3xkzY5+qZK3T5kvkIX1/rA6kE4HF4W8=",
+        "lastModified": 1779770395,
+        "narHash": "sha256-ikbVvrGFXhUMSz407EvWQ6xsGCw0/W8z7TwQ8LeTZtw=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "a275516112bbff26ff5c4d6a99fcf261290ade70",
+        "rev": "bc3642b346d015033f5ef7a41cdc75194a1fee22",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778999127,
-        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
+        "lastModified": 1779604987,
+        "narHash": "sha256-ZQ5z+fVhxYKtIFwtqGp5O0PD84BM1riASvqDaN5Xs+s=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
+        "rev": "8fba98c80b48fa013820e0163c5096922fea4ddd",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/65fb947964bd44fc0008faf77d1fcb7a9f40bb32?narHash=sha256-wuOkjI6pRiN4sEn/EPBRnNW5cmcpvd7xtIM8y5LooAs%3D' (2026-05-19)
  → 'github:nix-community/disko/5ba0c9555c28685e57fa54c7a25e42c7efdbfc8d?narHash=sha256-EcCaSTKnmg2o4wLKaN1aqQFomwyhO7ik0bX9COdyCas%3D' (2026-05-25)
• Updated input 'home-manager':
    'github:nix-community/home-manager/928d72376949e222ea4f07b44828a55b0136422e?narHash=sha256-n1%2Bl78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q%2Bd8%3D' (2026-05-21)
  → 'github:nix-community/home-manager/1a95e2efb477959b70b4a14c51035975c0481df6?narHash=sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA%3D' (2026-05-25)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/264f531e8a27cdefdbcfdd358d5ff7f5b372ffea?narHash=sha256-DGIvqkjbokN82rABjzybxMYxAC2FFmz6iOVHfntxw0A%3D' (2026-05-22)
  → 'github:homebrew/homebrew-cask/715791512131cd20e1819356ef2b3b840ff46177?narHash=sha256-HITU46GJUHS34Bzybu2Jh3w8B/41GI8cpb162usuIlw%3D' (2026-05-26)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/a275516112bbff26ff5c4d6a99fcf261290ade70?narHash=sha256-X55w6Q%2BlsTNz3xkzY5%2BqZK3T5kvkIX1/rA6kE4HF4W8%3D' (2026-05-22)
  → 'github:homebrew/homebrew-core/bc3642b346d015033f5ef7a41cdc75194a1fee22?narHash=sha256-ikbVvrGFXhUMSz407EvWQ6xsGCw0/W8z7TwQ8LeTZtw%3D' (2026-05-26)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/f680e0d3c1dbefe298c423691662e238496890f2?narHash=sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg%3D' (2026-05-17)
  → 'github:nix-community/nix-index-database/8fba98c80b48fa013820e0163c5096922fea4ddd?narHash=sha256-ZQ5z%2BfVhxYKtIFwtqGp5O0PD84BM1riASvqDaN5Xs%2Bs%3D' (2026-05-24)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb?narHash=sha256-30sZNZoA1cqF5JNO9fVX%2BwgiQYjB7HJqqJ4ztCDeBZE%3D' (2026-05-15)
  → 'github:NixOS/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'