### PR TITLE
fix(glyph): improve filebrowser-quantum startup reliability

### DIFF
--- a/modules/nixos/filebrowser-quantum.nix
+++ b/modules/nixos/filebrowser-quantum.nix
@@ -133,11 +133,14 @@ in {
   config = lib.mkIf cfg.enable {
     systemd = {
       services.filebrowser-quantum = {
-        after = ["network.target"];
+        after = ["network-online.target"];
+        wants = ["network-online.target"];
         description = "FileBrowser Quantum";
         wantedBy = ["multi-user.target"];
         serviceConfig =
           {
+            Restart = "on-failure";
+            RestartSec = "30s";
             ExecStart = let
               args = [
                 (lib.getExe cfg.package)


### PR DESCRIPTION
Wait for network-online.target so the OIDC issuer at id.zx.dev (hosted
on spore) is reachable before starting. Add Restart=on-failure with a
30s delay so transient OIDC unavailability at boot self-recovers without
manual intervention.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>