### PR TITLE
chore: work around crates.io 403 by injecting User-Agent into fetchcrate

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -8,4 +8,7 @@
 
   # Override opencode ahead of nixpkgs pin
   (import ./opencode.nix)
+
+  # Inject User-Agent into fetchcrate so crates.io doesn't 403
+  (import ./fetchcrate-ua.nix)
 ]

--- a/overlays/fetchcrate-ua.nix
+++ b/overlays/fetchcrate-ua.nix
@@ -1,0 +1,16 @@
+# Workaround for crates.io blocking bare curl User-Agents (HTTP 403).
+# crates.io enforces a data access policy requiring descriptive User-Agents;
+# nixpkgs fetchcrate sends none. Remove this overlay once upstream fixes it.
+# https://crates.io/data-access
+final: prev: {
+  fetchcrate = args:
+    prev.fetchcrate (args
+      // {
+        curlOptsList =
+          (args.curlOptsList or [])
+          ++ [
+            "--user-agent"
+            "cargo/1.0 (nixpkgs; https://github.com/NixOS/nixpkgs)"
+          ];
+      });
+}


### PR DESCRIPTION
crates.io now returns HTTP 403 for requests from bare curl User-Agents
under their API data access policy. nixpkgs fetchcrate sends no
User-Agent, breaking any Rust package that fetches crates at build time
(e.g. deploy-rs). This overlay wraps fetchcrate to inject a cargo-style
User-Agent until nixpkgs fixes it upstream.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>