### PR TITLE
fix(glyph): update kagi-mcp for FastMCP API change

### DIFF
--- a/modules/nixos/llm/kagi.nix
+++ b/modules/nixos/llm/kagi.nix
@@ -9,9 +9,7 @@
   startScript = pkgs.writeShellScript "kagi-mcp-start" ''
     exec ${lib.getExe pkgs.uv} run --with kagimcp python -c "
     from kagimcp.server import mcp
-    mcp.settings.host = '${cfg.host}'
-    mcp.settings.port = ${toString cfg.port}
-    mcp.run(transport='streamable-http')
+    mcp.run(transport='streamable-http', host='${cfg.host}', port=${toString cfg.port})
     "
   '';
 in {


### PR DESCRIPTION
FastMCP dropped the .settings attribute; host/port are now kwargs passed
directly to mcp.run(). Fixes kagi-mcp.service crash on startup.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>