### PR TITLE
feat(lobtop): add cmux module with declarative ghostty and cmux config

### DIFF
--- a/hosts/lobtop/programs.nix
+++ b/hosts/lobtop/programs.nix
@@ -65,6 +65,7 @@
 
     settings = {
       app.minimalMode = true;
+      notifications.showInMenuBar = false;
       ui.surfaceTabBar.buttons = [
         "cmux.newTerminal"
         "cmux.splitRight"

--- a/hosts/lobtop/programs.nix
+++ b/hosts/lobtop/programs.nix
@@ -59,4 +59,77 @@
     enable = true;
     startOnActivation = true;
   };
+
+  programs.cmux = {
+    enable = true;
+
+    settings = {
+      app.minimalMode = true;
+      ui.surfaceTabBar.buttons = [
+        "cmux.newTerminal"
+        "cmux.splitRight"
+        "cmux.splitDown"
+      ];
+      workspaceColors = {
+        notificationBadgeColor = null;
+        indicatorStyle = "leftRail";
+        selectionColor = null;
+        colors = {
+          Red = "#ff7b72";
+          Orange = "#ffa657";
+          Green = "#7ee787";
+          Blue = "#79c0ff";
+          Sky = "#a5d6ff";
+          Purple = "#d2a8ff";
+          Pink = "#ff6ac1";
+          Cyan = "#9aedfe";
+        };
+      };
+      shortcuts.bindings = {
+        openFolder = "";
+        reopenPreviousSession = "";
+        goToWorkspace = "cmd+o";
+        commandPalette = "cmd+p";
+        nextSurface = "cmd+opt+→";
+        prevSurface = "cmd+opt+←";
+        nextSidebarTab = "cmd+opt+↓";
+        prevSidebarTab = "cmd+opt+↑";
+        closeOtherTabsInPane = "";
+        selectSurfaceByNumber = "cmd+1";
+        selectWorkspaceByNumber = "ctrl+1";
+      };
+    };
+
+    ghostty = {
+      settings = {
+        background = "#131313";
+        foreground = "#dddddd";
+        "cursor-color" = "#dddddd";
+        "selection-background" = "#353436";
+        "selection-foreground" = "#dddddd";
+        "font-family" = "MesloLGSDZ Nerd Font Mono";
+        "font-size" = 12;
+        "window-padding-x" = 8;
+        "window-padding-y" = 8;
+      };
+      palette = {
+        "0" = "#131313";
+        "1" = "#ff5c57";
+        "2" = "#5af78e";
+        "3" = "#f3f99d";
+        "4" = "#57c7ff";
+        "5" = "#ff6ac1";
+        "6" = "#9aedfe";
+        "7" = "#caccca";
+        "8" = "#686868";
+        "9" = "#ff7b72";
+        "10" = "#7ee787";
+        "11" = "#ffa657";
+        "12" = "#79c0ff";
+        "13" = "#d2a8ff";
+        "14" = "#a5d6ff";
+        "15" = "#ffffff";
+      };
+    };
+  };
 }

--- a/modules/darwin/programs/cmux.nix
+++ b/modules/darwin/programs/cmux.nix
@@ -1,0 +1,102 @@
+{
+  config,
+  lib,
+  pkgs,
+  username,
+  ...
+}:
+with lib; let
+  cfg = config.programs.cmux;
+
+  jsonFormat = pkgs.formats.json {};
+
+  valueToString = v:
+    if isBool v
+    then boolToString v
+    else toString v;
+
+  ghosttyConfigText =
+    concatStringsSep "\n" (
+      mapAttrsToList (k: v: "${k} = ${valueToString v}") cfg.ghostty.settings
+      ++ map (idx: "palette = ${idx}=${cfg.ghostty.palette.${idx}}")
+      (sort (a: b: toInt a < toInt b) (attrNames cfg.ghostty.palette))
+    )
+    + "\n";
+in {
+  options.programs.cmux = {
+    enable = mkEnableOption "cmux";
+
+    settings = mkOption {
+      inherit (jsonFormat) type;
+      default = {};
+      description = ''
+        Configuration written to {file}`~/.config/cmux/cmux.json`.
+        Keys map directly to cmux JSON config fields.
+      '';
+      example = literalExpression ''
+        {
+          schemaVersion = 1;
+          app.minimalMode = true;
+          shortcuts.bindings = {
+            goToWorkspace = "cmd+o";
+            commandPalette = "cmd+p";
+          };
+        }
+      '';
+    };
+
+    ghostty = {
+      settings = mkOption {
+        type = types.attrsOf (types.oneOf [types.str types.int types.float types.bool]);
+        default = {};
+        description = ''
+          Ghostty settings written to {file}`~/.config/ghostty/config`
+          as `key = value` pairs.
+        '';
+        example = literalExpression ''
+          {
+            background = "#131313";
+            foreground = "#dddddd";
+            "cursor-color" = "#dddddd";
+            "font-family" = "MesloLGSDZ Nerd Font Mono";
+            "font-size" = 12;
+          }
+        '';
+      };
+
+      palette = mkOption {
+        type = types.attrsOf types.str;
+        default = {};
+        description = ''
+          Terminal color palette written as `palette = <index>=<color>` lines
+          in {file}`~/.config/ghostty/config`. Keys must be numeric strings "0"–"15".
+        '';
+        example = literalExpression ''
+          {
+            "0" = "#131313";
+            "1" = "#ff5c57";
+            "15" = "#ffffff";
+          }
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    homebrew.casks = ["cmux"];
+
+    home-manager.users.${username} = {
+      xdg.configFile."cmux/cmux.json" = {
+        source = jsonFormat.generate "cmux-config" ({
+            "$schema" = "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json";
+            schemaVersion = 1;
+          }
+          // cfg.settings);
+      };
+
+      xdg.configFile."ghostty/config" = mkIf (cfg.ghostty.settings != {} || cfg.ghostty.palette != {}) {
+        text = ghosttyConfigText;
+      };
+    };
+  };
+}

--- a/modules/darwin/programs/default.nix
+++ b/modules/darwin/programs/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./chromium.nix
+    ./cmux.nix
     ./craft.nix
     ./daisydisk.nix
     ./fastscripts.nix


### PR DESCRIPTION
## Summary

- Adds `modules/darwin/programs/cmux.nix` with a `programs.cmux.enable` option that installs cmux via Homebrew
- Declaratively manages `~/.config/cmux/cmux.json` via `programs.cmux.settings` (JSON format); `$schema` and `schemaVersion` are injected by the module automatically
- Declaratively manages `~/.config/ghostty/config` via `programs.cmux.ghostty.settings` and `programs.cmux.ghostty.palette`
- Enables the module in `hosts/lobtop/programs.nix` with settings matching the existing hand-written config files

## Test plan

- [ ] Run `nh darwin switch .#lobtop` and verify cmux is installed
- [ ] Verify `~/.config/cmux/cmux.json` is generated with correct content including `$schema` and `schemaVersion`
- [ ] Verify `~/.config/ghostty/config` is generated with correct colors, font, and all 16 palette entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)