### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779726696,
-        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
+        "lastModified": 1779969295,
+        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
+        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1779955944,
-        "narHash": "sha256-BH25fVgrizibC8bVjz/z59c6Q7SAwaLQX1vddQBlRVI=",
+        "lastModified": 1780044188,
+        "narHash": "sha256-+FV/4KdPMzR4UabG3EYb6I5IZPM4vncz+rfiMCRfG7Q=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "1c4eb69256ccf7cfcfc9fef84f6dd8f25d2aa9a6",
+        "rev": "dafc6209775c73fea289046a75af39a6ae0b2c6b",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1779948446,
-        "narHash": "sha256-d0r9ELwru9RenXqqFGjTgoMnfFXzUnA0YdLJi8j9dPs=",
+        "lastModified": 1780044081,
+        "narHash": "sha256-mXXJUF12Bv0bNgX8d+tMnABP2pxPpS+edAyxisRPvxU=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "8bc7973b7627c17a3b03f5096457bc2f05c0c6d8",
+        "rev": "8cc231b7b41bd50df4dc43acfd170d5fe7fb1928",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/1a95e2efb477959b70b4a14c51035975c0481df6?narHash=sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA%3D' (2026-05-25)
  → 'github:nix-community/home-manager/61e2c9659324181e0f0ed911958c536333b1d4f6?narHash=sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT%2Bd7rwOZMX7cTnA%3D' (2026-05-28)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/1c4eb69256ccf7cfcfc9fef84f6dd8f25d2aa9a6?narHash=sha256-BH25fVgrizibC8bVjz/z59c6Q7SAwaLQX1vddQBlRVI%3D' (2026-05-28)
  → 'github:homebrew/homebrew-cask/dafc6209775c73fea289046a75af39a6ae0b2c6b?narHash=sha256-%2BFV/4KdPMzR4UabG3EYb6I5IZPM4vncz%2BrfiMCRfG7Q%3D' (2026-05-29)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/8bc7973b7627c17a3b03f5096457bc2f05c0c6d8?narHash=sha256-d0r9ELwru9RenXqqFGjTgoMnfFXzUnA0YdLJi8j9dPs%3D' (2026-05-28)
  → 'github:homebrew/homebrew-core/8cc231b7b41bd50df4dc43acfd170d5fe7fb1928?narHash=sha256-mXXJUF12Bv0bNgX8d%2BtMnABP2pxPpS%2BedAyxisRPvxU%3D' (2026-05-29)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'