### PR TITLE
feat(Rhizome): enable cmux with shared defaults

### DIFF
--- a/hosts/Rhizome/programs.nix
+++ b/hosts/Rhizome/programs.nix
@@ -99,6 +99,6 @@
 
   programs.cmux = {
     enable = true;
-    defaults.enable = true;
+    enableDefaults = true;
   };
 }

--- a/hosts/Rhizome/programs.nix
+++ b/hosts/Rhizome/programs.nix
@@ -96,4 +96,9 @@
     enable = true;
     startOnActivation = true;
   };
+
+  programs.cmux = {
+    enable = true;
+    defaults.enable = true;
+  };
 }

--- a/hosts/lobtop/programs.nix
+++ b/hosts/lobtop/programs.nix
@@ -58,7 +58,7 @@
 
   programs.cmux = {
     enable = true;
-    defaults.enable = true;
+    enableDefaults = true;
     settings.notifications.showInMenuBar = false;
   };
 }

--- a/hosts/lobtop/programs.nix
+++ b/hosts/lobtop/programs.nix
@@ -58,75 +58,7 @@
 
   programs.cmux = {
     enable = true;
-
-    settings = {
-      app.minimalMode = true;
-      notifications.showInMenuBar = false;
-      ui.surfaceTabBar.buttons = [
-        "cmux.newTerminal"
-        "cmux.splitRight"
-        "cmux.splitDown"
-      ];
-      workspaceColors = {
-        notificationBadgeColor = null;
-        indicatorStyle = "leftRail";
-        selectionColor = null;
-        colors = {
-          Red = "#ff7b72";
-          Orange = "#ffa657";
-          Green = "#7ee787";
-          Blue = "#79c0ff";
-          Sky = "#a5d6ff";
-          Purple = "#d2a8ff";
-          Pink = "#ff6ac1";
-          Cyan = "#9aedfe";
-        };
-      };
-      shortcuts.bindings = {
-        openFolder = "";
-        reopenPreviousSession = "";
-        goToWorkspace = "cmd+o";
-        commandPalette = "cmd+p";
-        nextSurface = "cmd+opt+→";
-        prevSurface = "cmd+opt+←";
-        nextSidebarTab = "cmd+opt+↓";
-        prevSidebarTab = "cmd+opt+↑";
-        closeOtherTabsInPane = "";
-        selectSurfaceByNumber = "cmd+1";
-        selectWorkspaceByNumber = "ctrl+1";
-      };
-    };
-
-    ghostty = {
-      settings = {
-        background = "#131313";
-        foreground = "#dddddd";
-        "cursor-color" = "#dddddd";
-        "selection-background" = "#353436";
-        "selection-foreground" = "#dddddd";
-        "font-family" = "MesloLGSDZ Nerd Font Mono";
-        "font-size" = 12;
-        "window-padding-x" = 8;
-        "window-padding-y" = 8;
-      };
-      palette = {
-        "0" = "#131313";
-        "1" = "#ff5c57";
-        "2" = "#5af78e";
-        "3" = "#f3f99d";
-        "4" = "#57c7ff";
-        "5" = "#ff6ac1";
-        "6" = "#9aedfe";
-        "7" = "#caccca";
-        "8" = "#686868";
-        "9" = "#ff7b72";
-        "10" = "#7ee787";
-        "11" = "#ffa657";
-        "12" = "#79c0ff";
-        "13" = "#d2a8ff";
-        "14" = "#a5d6ff";
-        "15" = "#ffffff";
-      };
-    };
+    defaults.enable = true;
+    settings.notifications.showInMenuBar = false;
   };
 }

--- a/hosts/lobtop/programs.nix
+++ b/hosts/lobtop/programs.nix
@@ -59,6 +59,5 @@
   programs.cmux = {
     enable = true;
     enableDefaults = true;
-    settings.notifications.showInMenuBar = false;
   };
 }

--- a/modules/darwin/programs/cmux.nix
+++ b/modules/darwin/programs/cmux.nix
@@ -62,6 +62,7 @@ in {
     (mkIf cfg.enableDefaults {
       programs.cmux.settings = {
         app.minimalMode = mkDefault true;
+        notifications.showInMenuBar = mkDefault false;
         ui.surfaceTabBar.buttons = mkDefault [
           "cmux.newTerminal"
           "cmux.splitRight"

--- a/modules/darwin/programs/cmux.nix
+++ b/modules/darwin/programs/cmux.nix
@@ -26,22 +26,16 @@ in {
   options.programs.cmux = {
     enable = mkEnableOption "cmux";
 
+    defaults = {
+      enable = mkEnableOption "cmux and ghostty shared defaults";
+    };
+
     settings = mkOption {
       inherit (jsonFormat) type;
       default = {};
       description = ''
         Configuration written to {file}`~/.config/cmux/cmux.json`.
         Keys map directly to cmux JSON config fields.
-      '';
-      example = literalExpression ''
-        {
-          schemaVersion = 1;
-          app.minimalMode = true;
-          shortcuts.bindings = {
-            goToWorkspace = "cmd+o";
-            commandPalette = "cmd+p";
-          };
-        }
       '';
     };
 
@@ -53,15 +47,6 @@ in {
           Ghostty settings written to {file}`~/.config/ghostty/config`
           as `key = value` pairs.
         '';
-        example = literalExpression ''
-          {
-            background = "#131313";
-            foreground = "#dddddd";
-            "cursor-color" = "#dddddd";
-            "font-family" = "MesloLGSDZ Nerd Font Mono";
-            "font-size" = 12;
-          }
-        '';
       };
 
       palette = mkOption {
@@ -71,32 +56,98 @@ in {
           Terminal color palette written as `palette = <index>=<color>` lines
           in {file}`~/.config/ghostty/config`. Keys must be numeric strings "0"–"15".
         '';
-        example = literalExpression ''
-          {
-            "0" = "#131313";
-            "1" = "#ff5c57";
-            "15" = "#ffffff";
-          }
-        '';
       };
     };
   };
 
-  config = mkIf cfg.enable {
-    homebrew.casks = ["cmux"];
-
-    home-manager.users.${username} = {
-      xdg.configFile."cmux/cmux.json" = {
-        source = jsonFormat.generate "cmux-config" ({
-            "$schema" = "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json";
-            schemaVersion = 1;
-          }
-          // cfg.settings);
+  config = mkMerge [
+    (mkIf cfg.defaults.enable {
+      programs.cmux.settings = {
+        app.minimalMode = mkDefault true;
+        ui.surfaceTabBar.buttons = mkDefault [
+          "cmux.newTerminal"
+          "cmux.splitRight"
+          "cmux.splitDown"
+        ];
+        workspaceColors = mkDefault {
+          notificationBadgeColor = null;
+          indicatorStyle = "leftRail";
+          selectionColor = null;
+          colors = {
+            Red = "#ff7b72";
+            Orange = "#ffa657";
+            Green = "#7ee787";
+            Blue = "#79c0ff";
+            Sky = "#a5d6ff";
+            Purple = "#d2a8ff";
+            Pink = "#ff6ac1";
+            Cyan = "#9aedfe";
+          };
+        };
+        shortcuts.bindings = mkDefault {
+          openFolder = "";
+          reopenPreviousSession = "";
+          goToWorkspace = "cmd+o";
+          commandPalette = "cmd+p";
+          nextSurface = "cmd+opt+→";
+          prevSurface = "cmd+opt+←";
+          nextSidebarTab = "cmd+opt+↓";
+          prevSidebarTab = "cmd+opt+↑";
+          closeOtherTabsInPane = "";
+          selectSurfaceByNumber = "cmd+1";
+          selectWorkspaceByNumber = "ctrl+1";
+        };
       };
 
-      xdg.configFile."ghostty/config" = mkIf (cfg.ghostty.settings != {} || cfg.ghostty.palette != {}) {
-        text = ghosttyConfigText;
+      programs.cmux.ghostty = {
+        settings = mapAttrs (_: mkDefault) {
+          background = "#131313";
+          foreground = "#dddddd";
+          "cursor-color" = "#dddddd";
+          "selection-background" = "#353436";
+          "selection-foreground" = "#dddddd";
+          "font-family" = "MesloLGSDZ Nerd Font Mono";
+          "font-size" = 12;
+          "window-padding-x" = 8;
+          "window-padding-y" = 8;
+        };
+        palette = mapAttrs (_: mkDefault) {
+          "0" = "#131313";
+          "1" = "#ff5c57";
+          "2" = "#5af78e";
+          "3" = "#f3f99d";
+          "4" = "#57c7ff";
+          "5" = "#ff6ac1";
+          "6" = "#9aedfe";
+          "7" = "#caccca";
+          "8" = "#686868";
+          "9" = "#ff7b72";
+          "10" = "#7ee787";
+          "11" = "#ffa657";
+          "12" = "#79c0ff";
+          "13" = "#d2a8ff";
+          "14" = "#a5d6ff";
+          "15" = "#ffffff";
+        };
       };
-    };
-  };
+    })
+
+    (mkIf cfg.enable {
+      homebrew.casks = ["cmux"];
+
+      home-manager.users.${username} = {
+        xdg.configFile."cmux/cmux.json" = {
+          source = jsonFormat.generate "cmux-config" ({
+              "$schema" = "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json";
+              schemaVersion = 1;
+            }
+            // cfg.settings);
+        };
+
+        xdg.configFile."ghostty/config" = mkIf (cfg.ghostty.settings != {} || cfg.ghostty.palette != {}) {
+          text = ghosttyConfigText;
+        };
+      };
+    })
+  ];
 }

--- a/modules/darwin/programs/cmux.nix
+++ b/modules/darwin/programs/cmux.nix
@@ -26,9 +26,7 @@ in {
   options.programs.cmux = {
     enable = mkEnableOption "cmux";
 
-    defaults = {
-      enable = mkEnableOption "cmux and ghostty shared defaults";
-    };
+    enableDefaults = mkEnableOption "cmux and ghostty shared defaults";
 
     settings = mkOption {
       inherit (jsonFormat) type;
@@ -61,7 +59,7 @@ in {
   };
 
   config = mkMerge [
-    (mkIf cfg.defaults.enable {
+    (mkIf cfg.enableDefaults {
       programs.cmux.settings = {
         app.minimalMode = mkDefault true;
         ui.surfaceTabBar.buttons = mkDefault [


### PR DESCRIPTION
## Summary

- Adds `programs.cmux.defaults.enable` to the cmux module, which populates `settings` and `ghostty` with the Nova Dark theme and standard keybindings using `mkDefault` — hosts can override any individual key without `mkForce`
- Refactors `hosts/lobtop/programs.nix` to use `defaults.enable = true`, with `notifications.showInMenuBar = false` as a host-specific override
- Enables cmux on Rhizome with `enable = true; defaults.enable = true`

## Test plan

- [ ] Run `nh darwin switch .#Rhizome` and verify cmux is installed
- [ ] Verify `~/.config/cmux/cmux.json` and `~/.config/ghostty/config` are generated with the shared defaults
- [ ] Run `nh darwin switch .#lobtop` and verify the generated configs are unchanged from before this refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)