### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779942106,
-        "narHash": "sha256-81sATQ+hMCcsqFCN5UyhCoXXf62yQfKtzKzuiFXtdxA=",
+        "lastModified": 1780048612,
+        "narHash": "sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "36c1d04e85fc70f7b94f7434b1ea0a1a13bda4cd",
+        "rev": "caa775cf67bfdc47f940edd96c975b5016df9059",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779969295,
-        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
+        "lastModified": 1780099287,
+        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
+        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1780044188,
-        "narHash": "sha256-+FV/4KdPMzR4UabG3EYb6I5IZPM4vncz+rfiMCRfG7Q=",
+        "lastModified": 1780126741,
+        "narHash": "sha256-SseWE91U6IhgZ7w8XkMgQXDhFia8WG2wX7bZ7goOi14=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "dafc6209775c73fea289046a75af39a6ae0b2c6b",
+        "rev": "53a01c2a35f3a25ce9d8020d0538b5bf415e89ca",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1780044081,
-        "narHash": "sha256-mXXJUF12Bv0bNgX8d+tMnABP2pxPpS+edAyxisRPvxU=",
+        "lastModified": 1780119395,
+        "narHash": "sha256-vKCbgbvBTY7obtBJtKHzgvgrgkkSj14hpO/A3bk5EhY=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "8cc231b7b41bd50df4dc43acfd170d5fe7fb1928",
+        "rev": "b55d20796692e212bc2317fa7045aabe139e578f",
         "type": "github"
       },
       "original": {
@@ -447,12 +447,15 @@
       }
     },
     "nixos-hardware": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1779826373,
-        "narHash": "sha256-3sRzgLX86qV5NlhWUAufLmHwkyP03tmL3VdZIM13dEo=",
+        "lastModified": 1780065812,
+        "narHash": "sha256-SCSLUKBmwlSLGQ8Xbr8PjRFtiHNk0l9ktqkcmqdBkfE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ef4efb84766a166c906bd55759574676bf91267c",
+        "rev": "b76b5639c0593e0aeb0b5879ad62d4b30596c144",
         "type": "github"
       },
       "original": {
@@ -463,18 +466,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
-        "type": "github"
+        "lastModified": 1767892417,
+        "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
+        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre924538.3497aa5c9457/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs-stable": {
@@ -509,6 +509,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agenix": "agenix",
@@ -526,7 +542,7 @@
         "nix-homebrew": "nix-homebrew",
         "nix-index-database": "nix-index-database",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-stable-24-05": "nixpkgs-stable-24-05",
         "systems": "systems_2",
         "zx-dev": "zx-dev"


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/36c1d04e85fc70f7b94f7434b1ea0a1a13bda4cd?narHash=sha256-81sATQ%2BhMCcsqFCN5UyhCoXXf62yQfKtzKzuiFXtdxA%3D' (2026-05-28)
  → 'github:nix-community/disko/caa775cf67bfdc47f940edd96c975b5016df9059?narHash=sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU%3D' (2026-05-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/61e2c9659324181e0f0ed911958c536333b1d4f6?narHash=sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT%2Bd7rwOZMX7cTnA%3D' (2026-05-28)
  → 'github:nix-community/home-manager/7d8127d308c3fb9664f7e643eec944be74ebb37d?narHash=sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ%3D' (2026-05-30)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/dafc6209775c73fea289046a75af39a6ae0b2c6b?narHash=sha256-%2BFV/4KdPMzR4UabG3EYb6I5IZPM4vncz%2BrfiMCRfG7Q%3D' (2026-05-29)
  → 'github:homebrew/homebrew-cask/53a01c2a35f3a25ce9d8020d0538b5bf415e89ca?narHash=sha256-SseWE91U6IhgZ7w8XkMgQXDhFia8WG2wX7bZ7goOi14%3D' (2026-05-30)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/8cc231b7b41bd50df4dc43acfd170d5fe7fb1928?narHash=sha256-mXXJUF12Bv0bNgX8d%2BtMnABP2pxPpS%2BedAyxisRPvxU%3D' (2026-05-29)
  → 'github:homebrew/homebrew-core/b55d20796692e212bc2317fa7045aabe139e578f?narHash=sha256-vKCbgbvBTY7obtBJtKHzgvgrgkkSj14hpO/A3bk5EhY%3D' (2026-05-30)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/ef4efb84766a166c906bd55759574676bf91267c?narHash=sha256-3sRzgLX86qV5NlhWUAufLmHwkyP03tmL3VdZIM13dEo%3D' (2026-05-26)
  → 'github:NixOS/nixos-hardware/b76b5639c0593e0aeb0b5879ad62d4b30596c144?narHash=sha256-SCSLUKBmwlSLGQ8Xbr8PjRFtiHNk0l9ktqkcmqdBkfE%3D' (2026-05-29)
• Added input 'nixos-hardware/nixpkgs':
    'https://releases.nixos.org/nixos/unstable/nixos-26.05pre924538.3497aa5c9457/nixexprs.tar.xz?narHash=sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U%3D' (2026-01-08)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'