### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780048612,
-        "narHash": "sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU=",
+        "lastModified": 1780290312,
+        "narHash": "sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "caa775cf67bfdc47f940edd96c975b5016df9059",
+        "rev": "115e5211780054d8a890b41f0b7734cafad54dfe",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099287,
-        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
+        "lastModified": 1780370888,
+        "narHash": "sha256-PRJj9RKTEf/sITycujP1c/BrvLJKMYXzcpwTsXNulXQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
+        "rev": "a7a415883195ffbd4dabec8f098f201e6eaaadf8",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1780208174,
-        "narHash": "sha256-SLIkCL9bMS8t8hPIYWf/9MQr+EDcqDIbU402+VjgBuU=",
+        "lastModified": 1780391438,
+        "narHash": "sha256-tLBcEqBciHErL3VGcxEzFH3BVEeP8YrkMzc68nK28+M=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "42df01dff1c827f73c96c925dc641ba199353ba8",
+        "rev": "6bb5391de7235200bc0caef10b0f9afdb06d2bd2",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1780214907,
-        "narHash": "sha256-tyuepCwSgQXqKKrI8aW+RFP6NkaUrAJ33hlD3cdYPd8=",
+        "lastModified": 1780380829,
+        "narHash": "sha256-8KQIGvIvPXjFEjjmzhI9w/ZzNLe+jyoS71eH0HTBgL4=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "22dd690183090cf7a0356bfc30c00ac804db6db5",
+        "rev": "f77877c7981906d77bb5fe826936a20e125bf13f",
         "type": "github"
       },
       "original": {
@@ -451,11 +451,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780065812,
-        "narHash": "sha256-SCSLUKBmwlSLGQ8Xbr8PjRFtiHNk0l9ktqkcmqdBkfE=",
+        "lastModified": 1780310866,
+        "narHash": "sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b76b5639c0593e0aeb0b5879ad62d4b30596c144",
+        "rev": "4ed851c979641e28597a05086332d75cdc9e395f",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/caa775cf67bfdc47f940edd96c975b5016df9059?narHash=sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU%3D' (2026-05-29)
  → 'github:nix-community/disko/115e5211780054d8a890b41f0b7734cafad54dfe?narHash=sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo%3D' (2026-06-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/7d8127d308c3fb9664f7e643eec944be74ebb37d?narHash=sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ%3D' (2026-05-30)
  → 'github:nix-community/home-manager/a7a415883195ffbd4dabec8f098f201e6eaaadf8?narHash=sha256-PRJj9RKTEf/sITycujP1c/BrvLJKMYXzcpwTsXNulXQ%3D' (2026-06-02)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/42df01dff1c827f73c96c925dc641ba199353ba8?narHash=sha256-SLIkCL9bMS8t8hPIYWf/9MQr%2BEDcqDIbU402%2BVjgBuU%3D' (2026-05-31)
  → 'github:homebrew/homebrew-cask/6bb5391de7235200bc0caef10b0f9afdb06d2bd2?narHash=sha256-tLBcEqBciHErL3VGcxEzFH3BVEeP8YrkMzc68nK28%2BM%3D' (2026-06-02)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/22dd690183090cf7a0356bfc30c00ac804db6db5?narHash=sha256-tyuepCwSgQXqKKrI8aW%2BRFP6NkaUrAJ33hlD3cdYPd8%3D' (2026-05-31)
  → 'github:homebrew/homebrew-core/f77877c7981906d77bb5fe826936a20e125bf13f?narHash=sha256-8KQIGvIvPXjFEjjmzhI9w/ZzNLe%2BjyoS71eH0HTBgL4%3D' (2026-06-02)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/b76b5639c0593e0aeb0b5879ad62d4b30596c144?narHash=sha256-SCSLUKBmwlSLGQ8Xbr8PjRFtiHNk0l9ktqkcmqdBkfE%3D' (2026-05-29)
  → 'github:NixOS/nixos-hardware/4ed851c979641e28597a05086332d75cdc9e395f?narHash=sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I%3D' (2026-06-01)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786?narHash=sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o%3D' (2026-05-23)
  → 'github:NixOS/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c?narHash=sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw%3D' (2026-05-31)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'