### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780370888,
-        "narHash": "sha256-PRJj9RKTEf/sITycujP1c/BrvLJKMYXzcpwTsXNulXQ=",
+        "lastModified": 1780408569,
+        "narHash": "sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7a415883195ffbd4dabec8f098f201e6eaaadf8",
+        "rev": "f384af1bec6423a0d4ba1855917ab948f64e5808",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1780391438,
-        "narHash": "sha256-tLBcEqBciHErL3VGcxEzFH3BVEeP8YrkMzc68nK28+M=",
+        "lastModified": 1780475877,
+        "narHash": "sha256-yp2GDABJF4zsXLbg3ehqOXHHMSZH8+NJJAi5YO2rqms=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "6bb5391de7235200bc0caef10b0f9afdb06d2bd2",
+        "rev": "64fe32501e2f95d827252632afb01f94b1d818fa",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1780380829,
-        "narHash": "sha256-8KQIGvIvPXjFEjjmzhI9w/ZzNLe+jyoS71eH0HTBgL4=",
+        "lastModified": 1780467961,
+        "narHash": "sha256-qdVu4mhbYo7ua3wFGmVuc4IiLYhuh7yhuuAnfrqplgw=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "f77877c7981906d77bb5fe826936a20e125bf13f",
+        "rev": "6d320d46c695c417ac7297c0f0fa0c1379d78339",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/a7a415883195ffbd4dabec8f098f201e6eaaadf8?narHash=sha256-PRJj9RKTEf/sITycujP1c/BrvLJKMYXzcpwTsXNulXQ%3D' (2026-06-02)
  → 'github:nix-community/home-manager/f384af1bec6423a0d4ba1855917ab948f64e5808?narHash=sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg%3D' (2026-06-02)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/6bb5391de7235200bc0caef10b0f9afdb06d2bd2?narHash=sha256-tLBcEqBciHErL3VGcxEzFH3BVEeP8YrkMzc68nK28%2BM%3D' (2026-06-02)
  → 'github:homebrew/homebrew-cask/64fe32501e2f95d827252632afb01f94b1d818fa?narHash=sha256-yp2GDABJF4zsXLbg3ehqOXHHMSZH8%2BNJJAi5YO2rqms%3D' (2026-06-03)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/f77877c7981906d77bb5fe826936a20e125bf13f?narHash=sha256-8KQIGvIvPXjFEjjmzhI9w/ZzNLe%2BjyoS71eH0HTBgL4%3D' (2026-06-02)
  → 'github:homebrew/homebrew-core/6d320d46c695c417ac7297c0f0fa0c1379d78339?narHash=sha256-qdVu4mhbYo7ua3wFGmVuc4IiLYhuh7yhuuAnfrqplgw%3D' (2026-06-03)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'