### PR TITLE
feat(lobtop): install and configure Karabiner Elements

### DIFF
--- a/hosts/lobtop/programs.nix
+++ b/hosts/lobtop/programs.nix
@@ -21,60 +21,8 @@
 
   programs.karabiner = {
     enable = true;
+    enableDefaults = true;
     startOnActivation = true;
-    # MX Master 4 M (Logitech) — vendor 1133, product 45122
-    devices = [
-      {
-        identifiers = {
-          is_pointing_device = true;
-          product_id = 45122;
-          vendor_id = 1133;
-        };
-        ignore = false;
-      }
-    ];
-    complexModifications = [
-      {
-        description = "Mission control";
-        manipulators = [
-          {
-            type = "basic";
-            from.pointing_button = "button7";
-            to = [{key_code = "mission_control";}];
-          }
-        ];
-      }
-      {
-        description = "Thumb button → Right space";
-        manipulators = [
-          {
-            type = "basic";
-            from.pointing_button = "button4";
-            to = [
-              {
-                key_code = "right_arrow";
-                modifiers = ["control"];
-              }
-            ];
-          }
-        ];
-      }
-      {
-        description = "Thumb button → Left space";
-        manipulators = [
-          {
-            type = "basic";
-            from.pointing_button = "button5";
-            to = [
-              {
-                key_code = "left_arrow";
-                modifiers = ["control"];
-              }
-            ];
-          }
-        ];
-      }
-    ];
   };
 
   programs.fastscripts = {

--- a/hosts/lobtop/programs.nix
+++ b/hosts/lobtop/programs.nix
@@ -19,6 +19,64 @@
     enable = true;
   };
 
+  programs.karabiner = {
+    enable = true;
+    startOnActivation = true;
+    # MX Master 4 M (Logitech) — vendor 1133, product 45122
+    devices = [
+      {
+        identifiers = {
+          is_pointing_device = true;
+          product_id = 45122;
+          vendor_id = 1133;
+        };
+        ignore = false;
+      }
+    ];
+    complexModifications = [
+      {
+        description = "Mission control";
+        manipulators = [
+          {
+            type = "basic";
+            from.pointing_button = "button7";
+            to = [{key_code = "mission_control";}];
+          }
+        ];
+      }
+      {
+        description = "Thumb button → Right space";
+        manipulators = [
+          {
+            type = "basic";
+            from.pointing_button = "button4";
+            to = [
+              {
+                key_code = "right_arrow";
+                modifiers = ["control"];
+              }
+            ];
+          }
+        ];
+      }
+      {
+        description = "Thumb button → Left space";
+        manipulators = [
+          {
+            type = "basic";
+            from.pointing_button = "button5";
+            to = [
+              {
+                key_code = "left_arrow";
+                modifiers = ["control"];
+              }
+            ];
+          }
+        ];
+      }
+    ];
+  };
+
   programs.fastscripts = {
     enable = true;
     startOnActivation = true;

--- a/modules/darwin/programs/default.nix
+++ b/modules/darwin/programs/default.nix
@@ -6,6 +6,7 @@
     ./daisydisk.nix
     ./fastscripts.nix
     ./iina.nix
+    ./karabiner.nix
     ./little-snitch.nix
     ./popclip.nix
     ./postico.nix

--- a/modules/darwin/programs/karabiner.nix
+++ b/modules/darwin/programs/karabiner.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.programs.karabiner;
+
+  configJson = builtins.toJSON {
+    global.show_in_menu_bar = false;
+    profiles = [
+      {
+        complex_modifications.rules = cfg.complexModifications;
+        inherit (cfg) devices;
+        name = "Default profile";
+        selected = true;
+        virtual_hid_keyboard.keyboard_type_v2 = "ansi";
+      }
+    ];
+  };
+in {
+  options.programs.karabiner = {
+    enable = mkEnableOption "Karabiner-Elements";
+
+    startOnActivation = mkEnableOption "starting Karabiner-Elements on activation";
+
+    devices = mkOption {
+      type = types.listOf types.attrs;
+      default = [];
+      description = "Device entries to include in the Karabiner profile.";
+    };
+
+    complexModifications = mkOption {
+      type = types.listOf types.attrs;
+      default = [];
+      description = "Complex modification rules to include in the Karabiner profile.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [pkgs.karabiner-elements];
+
+    # Karabiner-Elements does not support being managed via defaults(1); write
+    # the JSON config directly during activation instead.
+    system.activationScripts.postActivation.text = let
+      user = lib.escapeShellArg config.system.primaryUser;
+      configFile = pkgs.writeText "karabiner.json" configJson;
+    in ''
+      echo "configuring karabiner-elements..." >&2
+      sudo --user=${user} -- mkdir -p ~${user}/.config/karabiner
+      sudo --user=${user} -- cp -f ${configFile} ~${user}/.config/karabiner/karabiner.json
+    '';
+
+    system.startOnActivation = mkIf cfg.startOnActivation {
+      "karabiner_observer" = "${pkgs.karabiner-elements}/Applications/Karabiner-Elements.app/";
+    };
+  };
+}

--- a/modules/darwin/programs/karabiner.nix
+++ b/modules/darwin/programs/karabiner.nix
@@ -23,6 +23,8 @@ in {
   options.programs.karabiner = {
     enable = mkEnableOption "Karabiner-Elements";
 
+    enableDefaults = mkEnableOption "default MX Master 4 M device and mission-control/space-switching complex modifications";
+
     startOnActivation = mkEnableOption "starting Karabiner-Elements on activation";
 
     devices = mkOption {
@@ -38,22 +40,79 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
-    environment.systemPackages = [pkgs.karabiner-elements];
+  config = mkMerge [
+    (mkIf cfg.enableDefaults {
+      programs.karabiner.devices = mkDefault [
+        # Logitech MX Master 4 M
+        {
+          identifiers = {
+            is_pointing_device = true;
+            product_id = 45122;
+            vendor_id = 1133;
+          };
+          ignore = false;
+        }
+      ];
+      programs.karabiner.complexModifications = mkDefault [
+        {
+          description = "Mission control";
+          manipulators = [
+            {
+              type = "basic";
+              from.pointing_button = "button7";
+              to = [{key_code = "mission_control";}];
+            }
+          ];
+        }
+        {
+          description = "Thumb button → Right space";
+          manipulators = [
+            {
+              type = "basic";
+              from.pointing_button = "button4";
+              to = [
+                {
+                  key_code = "right_arrow";
+                  modifiers = ["control"];
+                }
+              ];
+            }
+          ];
+        }
+        {
+          description = "Thumb button → Left space";
+          manipulators = [
+            {
+              type = "basic";
+              from.pointing_button = "button5";
+              to = [
+                {
+                  key_code = "left_arrow";
+                  modifiers = ["control"];
+                }
+              ];
+            }
+          ];
+        }
+      ];
+    })
+    (mkIf cfg.enable {
+      environment.systemPackages = [pkgs.karabiner-elements];
 
-    # Karabiner-Elements does not support being managed via defaults(1); write
-    # the JSON config directly during activation instead.
-    system.activationScripts.postActivation.text = let
-      user = lib.escapeShellArg config.system.primaryUser;
-      configFile = pkgs.writeText "karabiner.json" configJson;
-    in ''
-      echo "configuring karabiner-elements..." >&2
-      sudo --user=${user} -- mkdir -p ~${user}/.config/karabiner
-      sudo --user=${user} -- cp -f ${configFile} ~${user}/.config/karabiner/karabiner.json
-    '';
+      # Karabiner-Elements does not support being managed via defaults(1); write
+      # the JSON config directly during activation instead.
+      system.activationScripts.postActivation.text = let
+        user = lib.escapeShellArg config.system.primaryUser;
+        configFile = pkgs.writeText "karabiner.json" configJson;
+      in ''
+        echo "configuring karabiner-elements..." >&2
+        sudo --user=${user} -- mkdir -p ~${user}/.config/karabiner
+        sudo --user=${user} -- cp -f ${configFile} ~${user}/.config/karabiner/karabiner.json
+      '';
 
-    system.startOnActivation = mkIf cfg.startOnActivation {
-      "karabiner_observer" = "${pkgs.karabiner-elements}/Applications/Karabiner-Elements.app/";
-    };
-  };
+      system.startOnActivation = mkIf cfg.startOnActivation {
+        "karabiner_observer" = "${pkgs.karabiner-elements}/Applications/Karabiner-Elements.app/";
+      };
+    })
+  ];
 }


### PR DESCRIPTION
## Summary

- Adds a reusable `programs.karabiner` darwin module (`modules/darwin/programs/karabiner.nix`) that installs `karabiner-elements` from nixpkgs and writes `~/.config/karabiner/karabiner.json` during activation
- Enables it on `lobtop` with the MX Master 4 M (vendor 1133, product 45122) and the three existing complex modifications: mission control (button7), right space (button4), left space (button5)

## Test plan

- [ ] Run `nh darwin switch .#lobtop` and verify Karabiner Elements is installed
- [ ] Confirm `~/.config/karabiner/karabiner.json` matches the expected config (MX Master 4 M device enabled, 3 complex mod rules present)
- [ ] Verify the mouse buttons trigger mission control and space switching as expected
- [ ] Re-run switch and confirm the config file is idempotently overwritten without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)