### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -73,16 +73,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778427648,
-        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
+        "lastModified": 1779646357,
+        "narHash": "sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
+        "rev": "10a163ac127624caa80cc5cc5a705e97f3615b0e",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.11",
+        "ref": "5.1.14",
         "repo": "brew",
         "type": "github"
       }
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780408569,
-        "narHash": "sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg=",
+        "lastModified": 1780515920,
+        "narHash": "sha256-8KX2hEeOX6KP3hBBJJI8dGWVrzbOOf1rBPmg/GUG24U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f384af1bec6423a0d4ba1855917ab948f64e5808",
+        "rev": "4c5c1e8ba14f1c7475fa31ff11bc1c19cd220974",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1780475877,
-        "narHash": "sha256-yp2GDABJF4zsXLbg3ehqOXHHMSZH8+NJJAi5YO2rqms=",
+        "lastModified": 1780562610,
+        "narHash": "sha256-7+j38tyrqsFj5Z2YlCxqE4S00VyiYD9Gb2c9n9exElA=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "64fe32501e2f95d827252632afb01f94b1d818fa",
+        "rev": "046d6e61afe8c071922d1161feddc3bbdec1b2dd",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1780467961,
-        "narHash": "sha256-qdVu4mhbYo7ua3wFGmVuc4IiLYhuh7yhuuAnfrqplgw=",
+        "lastModified": 1780562756,
+        "narHash": "sha256-OWkDiaaZCcGWkM84jj9ihxBaTowGfPPDEkfJP5W2qo8=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "6d320d46c695c417ac7297c0f0fa0c1379d78339",
+        "rev": "be7845fd13229868b8b4e5b02dc0d82dc58f50c0",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1778851564,
-        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
+        "lastModified": 1780492467,
+        "narHash": "sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
+        "rev": "562332f97de9f5ba51aa647d70462e88222b2988",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/f384af1bec6423a0d4ba1855917ab948f64e5808?narHash=sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg%3D' (2026-06-02)
  → 'github:nix-community/home-manager/4c5c1e8ba14f1c7475fa31ff11bc1c19cd220974?narHash=sha256-8KX2hEeOX6KP3hBBJJI8dGWVrzbOOf1rBPmg/GUG24U%3D' (2026-06-03)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/64fe32501e2f95d827252632afb01f94b1d818fa?narHash=sha256-yp2GDABJF4zsXLbg3ehqOXHHMSZH8%2BNJJAi5YO2rqms%3D' (2026-06-03)
  → 'github:homebrew/homebrew-cask/046d6e61afe8c071922d1161feddc3bbdec1b2dd?narHash=sha256-7%2Bj38tyrqsFj5Z2YlCxqE4S00VyiYD9Gb2c9n9exElA%3D' (2026-06-04)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/6d320d46c695c417ac7297c0f0fa0c1379d78339?narHash=sha256-qdVu4mhbYo7ua3wFGmVuc4IiLYhuh7yhuuAnfrqplgw%3D' (2026-06-03)
  → 'github:homebrew/homebrew-core/be7845fd13229868b8b4e5b02dc0d82dc58f50c0?narHash=sha256-OWkDiaaZCcGWkM84jj9ihxBaTowGfPPDEkfJP5W2qo8%3D' (2026-06-04)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/b3a87b4793205cc111f3c61e25e018ffac3b8039?narHash=sha256-p8wzcnpB2Iys%2BQzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE%3D' (2026-05-15)
  → 'github:zhaofengli/nix-homebrew/562332f97de9f5ba51aa647d70462e88222b2988?narHash=sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY%3D' (2026-06-03)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/6f293daa9f9f5832e13b497976335e90509886d7?narHash=sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE%3D' (2026-05-10)
  → 'github:Homebrew/brew/10a163ac127624caa80cc5cc5a705e97f3615b0e?narHash=sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k%3D' (2026-05-24)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'