### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1780723578,
-        "narHash": "sha256-BWZriTfWdfn6uQxHQkML8FNjWWv+JkeP1ch9uujM42Q=",
+        "lastModified": 1780820025,
+        "narHash": "sha256-FqSLA2PWg3N46ZxS7mZxgf6Nbp4LGUgJNPtD4ebiokA=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "6f74dfb01c911360f6eebb3d5f9fae39b3afadff",
+        "rev": "3e31625ba6b8e7c806fadedc39f9c0701a9bd463",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1780729022,
-        "narHash": "sha256-txVcGOlt+CTom/t1SnC+aPjGB3gP9mzC7pLDYwkN8/g=",
+        "lastModified": 1780819574,
+        "narHash": "sha256-RTkiORPIrqwe/zCGBz3L/IbCqFaN2i6t6Ue5u3PcyTQ=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "c1599cc35573823428e3843ddc79eb1572406ac8",
+        "rev": "6a0a4d80be77a14baed953886a3623c91c975326",
         "type": "github"
       },
       "original": {
@@ -374,11 +374,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1780795403,
+        "narHash": "sha256-AkWx4Zt9pQbD/f82Z8N57+d0HGLN/rV3gdMKJTpBPKs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "6a771120d607dcccb279a27d227650e324815c35",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780210899,
-        "narHash": "sha256-4axz3OBPTKa6LIkXV8n0lc63MQU+et2CB5DGobEAi6k=",
+        "lastModified": 1780816331,
+        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "97df9dc0b7c924344b793a15c1e8e4522ebb854e",
+        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/6f74dfb01c911360f6eebb3d5f9fae39b3afadff?narHash=sha256-BWZriTfWdfn6uQxHQkML8FNjWWv%2BJkeP1ch9uujM42Q%3D' (2026-06-06)
  → 'github:homebrew/homebrew-cask/3e31625ba6b8e7c806fadedc39f9c0701a9bd463?narHash=sha256-FqSLA2PWg3N46ZxS7mZxgf6Nbp4LGUgJNPtD4ebiokA%3D' (2026-06-07)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/c1599cc35573823428e3843ddc79eb1572406ac8?narHash=sha256-txVcGOlt%2BCTom/t1SnC%2BaPjGB3gP9mzC7pLDYwkN8/g%3D' (2026-06-06)
  → 'github:homebrew/homebrew-core/6a0a4d80be77a14baed953886a3623c91c975326?narHash=sha256-RTkiORPIrqwe/zCGBz3L/IbCqFaN2i6t6Ue5u3PcyTQ%3D' (2026-06-07)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/56c666e108467d87d13508936aade6d567f2a501?narHash=sha256-zXcwYQGCT6pzinK%2B1dBB2ekTVtfxGZAapb3Evdcu4fY%3D' (2026-05-17)
  → 'github:LnL7/nix-darwin/6a771120d607dcccb279a27d227650e324815c35?narHash=sha256-AkWx4Zt9pQbD/f82Z8N57%2Bd0HGLN/rV3gdMKJTpBPKs%3D' (2026-06-07)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/97df9dc0b7c924344b793a15c1e8e4522ebb854e?narHash=sha256-4axz3OBPTKa6LIkXV8n0lc63MQU%2Bet2CB5DGobEAi6k%3D' (2026-05-31)
  → 'github:nix-community/nix-index-database/1a2ea89c917781e88508d9fd2b507f2d2a0e173c?narHash=sha256-0BYqs8yKWkOz2Q7%2BSP18N5E5gmDKSo6LSxIVIa0wWes%3D' (2026-06-07)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'