### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780290312,
-        "narHash": "sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo=",
+        "lastModified": 1780894562,
+        "narHash": "sha256-c3430xwxwhHipl3jigUGMMBfpaMylDqytW/kdmB3ZGs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "115e5211780054d8a890b41f0b7734cafad54dfe",
+        "rev": "24fed06cac83bcc44ac8efbb57cab1a82fa0bedc",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780679734,
-        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
+        "lastModified": 1780885330,
+        "narHash": "sha256-aMA5oAq2Iv467U9s8YOb50DYQT9w0WJbyWqwlzHuLMs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
+        "rev": "4fe95527cbe952713318ada8a4d122e1a6ab120f",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1780820025,
-        "narHash": "sha256-FqSLA2PWg3N46ZxS7mZxgf6Nbp4LGUgJNPtD4ebiokA=",
+        "lastModified": 1780911400,
+        "narHash": "sha256-aGhcpwguZ7u2qvEkjNbaEwDR6iRToEOUyUiGsMJEHws=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "3e31625ba6b8e7c806fadedc39f9c0701a9bd463",
+        "rev": "68a59b7fe21c48b83ffa595a0acda60d03b837b2",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1780819574,
-        "narHash": "sha256-RTkiORPIrqwe/zCGBz3L/IbCqFaN2i6t6Ue5u3PcyTQ=",
+        "lastModified": 1780909013,
+        "narHash": "sha256-+qBRz5yI1mqKS6Oep08prvFYA+gZDAAvbsuyNJ1r3Hw=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "6a0a4d80be77a14baed953886a3623c91c975326",
+        "rev": "104413d27aee438fe4f7dacb7ad0d0d429af8f03",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/115e5211780054d8a890b41f0b7734cafad54dfe?narHash=sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo%3D' (2026-06-01)
  → 'github:nix-community/disko/24fed06cac83bcc44ac8efbb57cab1a82fa0bedc?narHash=sha256-c3430xwxwhHipl3jigUGMMBfpaMylDqytW/kdmB3ZGs%3D' (2026-06-08)
• Updated input 'home-manager':
    'github:nix-community/home-manager/b2b7db486e06e098711dc291bb25db82850e1d16?narHash=sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8%3D' (2026-06-05)
  → 'github:nix-community/home-manager/4fe95527cbe952713318ada8a4d122e1a6ab120f?narHash=sha256-aMA5oAq2Iv467U9s8YOb50DYQT9w0WJbyWqwlzHuLMs%3D' (2026-06-08)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/3e31625ba6b8e7c806fadedc39f9c0701a9bd463?narHash=sha256-FqSLA2PWg3N46ZxS7mZxgf6Nbp4LGUgJNPtD4ebiokA%3D' (2026-06-07)
  → 'github:homebrew/homebrew-cask/68a59b7fe21c48b83ffa595a0acda60d03b837b2?narHash=sha256-aGhcpwguZ7u2qvEkjNbaEwDR6iRToEOUyUiGsMJEHws%3D' (2026-06-08)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/6a0a4d80be77a14baed953886a3623c91c975326?narHash=sha256-RTkiORPIrqwe/zCGBz3L/IbCqFaN2i6t6Ue5u3PcyTQ%3D' (2026-06-07)
  → 'github:homebrew/homebrew-core/104413d27aee438fe4f7dacb7ad0d0d429af8f03?narHash=sha256-%2BqBRz5yI1mqKS6Oep08prvFYA%2BgZDAAvbsuyNJ1r3Hw%3D' (2026-06-08)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c?narHash=sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw%3D' (2026-05-31)
  → 'github:NixOS/nixpkgs/a799d3e3886da994fa307f817a6bc705ae538eeb?narHash=sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY%3D' (2026-06-06)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'