### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -111,11 +111,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1780929542,
-        "narHash": "sha256-/DTEDl6pUIusBx3+QZ1is+imWtlUotm2L/AvK+YBuwk=",
+        "lastModified": 1781023725,
+        "narHash": "sha256-Gt+qFANcrDRjl3xzidLYrAUQCd3808iuAsLwZbYYAEU=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "1c1703ab92db600e4f5884d762ba9e22ebe7a41c",
+        "rev": "2ce9051767ee4d1a3c43b52ba327431783bfd463",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780943742,
-        "narHash": "sha256-01bTMR9ZPG+uxPaZBeOwagg5uxIaFYs2/3YIrOX+bCA=",
+        "lastModified": 1781064232,
+        "narHash": "sha256-+7cIaqM6ucKf5fDyMnkwehxG8tBdaU51TZOMtxacXmI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "df39142474950e42d5fc3bf2fef9d6c62abbe8d7",
+        "rev": "1ffdc28076a1809ee7c0cf08f06af18f31c480cd",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1780974498,
-        "narHash": "sha256-NEJSQY9OVENpzjcBNuKVE41qdZc22YBO4FK5edlFdYY=",
+        "lastModified": 1781068330,
+        "narHash": "sha256-f33bN9C/yAsxtabx2WW/nc0r5XfgjU5G+pHNoEKBkH0=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "b9b99ed383eab28a456c78576ff8a7b25e3daa43",
+        "rev": "2b37c8b92d0c4a1bd6c789b66fd97bd1bcd8ac87",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1780991649,
-        "narHash": "sha256-OI2Ag0YMJ9f4fsvZxlt0sfcuMybbij3oEHwYE6rvpcU=",
+        "lastModified": 1781075881,
+        "narHash": "sha256-QEFOVpjH7tyBfkTApTfiLRjsRBQ/zBymB8K8xA7+A1w=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "e8999b820a68b0de93378ae8cd5c5a4c377593cb",
+        "rev": "a82469f21cda20faabf149acdf95d95c256d8ac0",
         "type": "github"
       },
       "original": {
@@ -451,11 +451,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780310866,
-        "narHash": "sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I=",
+        "lastModified": 1781020964,
+        "narHash": "sha256-fS7xTi2j2iso5Hj7RNZLv/acDlCT+fgMVkVk40A7Uco=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4ed851c979641e28597a05086332d75cdc9e395f",
+        "rev": "32c2cd9e46286c4eced3dc6b613c659126bf3cca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'deploy-rs':
    'github:serokell/deploy-rs/1c1703ab92db600e4f5884d762ba9e22ebe7a41c?narHash=sha256-/DTEDl6pUIusBx3%2BQZ1is%2BimWtlUotm2L/AvK%2BYBuwk%3D' (2026-06-08)
  → 'github:serokell/deploy-rs/2ce9051767ee4d1a3c43b52ba327431783bfd463?narHash=sha256-Gt%2BqFANcrDRjl3xzidLYrAUQCd3808iuAsLwZbYYAEU%3D' (2026-06-09)
• Updated input 'home-manager':
    'github:nix-community/home-manager/df39142474950e42d5fc3bf2fef9d6c62abbe8d7?narHash=sha256-01bTMR9ZPG%2BuxPaZBeOwagg5uxIaFYs2/3YIrOX%2BbCA%3D' (2026-06-08)
  → 'github:nix-community/home-manager/1ffdc28076a1809ee7c0cf08f06af18f31c480cd?narHash=sha256-%2B7cIaqM6ucKf5fDyMnkwehxG8tBdaU51TZOMtxacXmI%3D' (2026-06-10)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/b9b99ed383eab28a456c78576ff8a7b25e3daa43?narHash=sha256-NEJSQY9OVENpzjcBNuKVE41qdZc22YBO4FK5edlFdYY%3D' (2026-06-09)
  → 'github:homebrew/homebrew-cask/2b37c8b92d0c4a1bd6c789b66fd97bd1bcd8ac87?narHash=sha256-f33bN9C/yAsxtabx2WW/nc0r5XfgjU5G%2BpHNoEKBkH0%3D' (2026-06-10)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/e8999b820a68b0de93378ae8cd5c5a4c377593cb?narHash=sha256-OI2Ag0YMJ9f4fsvZxlt0sfcuMybbij3oEHwYE6rvpcU%3D' (2026-06-09)
  → 'github:homebrew/homebrew-core/a82469f21cda20faabf149acdf95d95c256d8ac0?narHash=sha256-QEFOVpjH7tyBfkTApTfiLRjsRBQ/zBymB8K8xA7%2BA1w%3D' (2026-06-10)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/4ed851c979641e28597a05086332d75cdc9e395f?narHash=sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I%3D' (2026-06-01)
  → 'github:NixOS/nixos-hardware/32c2cd9e46286c4eced3dc6b613c659126bf3cca?narHash=sha256-fS7xTi2j2iso5Hj7RNZLv/acDlCT%2BfgMVkVk40A7Uco%3D' (2026-06-09)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'