### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1758711588,
-        "narHash": "sha256-0nZlCCDC5PfndsQJXXtcyrtrfW49I3KadGMDlutzaGU=",
+        "lastModified": 1781150914,
+        "narHash": "sha256-I2cjqxsVyoqAKl1/egoIDV5h96ACOdf9RQZz+2dBvAk=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "12cbeca141f46e1ade76728bce8adc447f2166c6",
+        "rev": "295a33a1e4a5138868e6f45dc75ed68a05c0300f",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780894562,
-        "narHash": "sha256-c3430xwxwhHipl3jigUGMMBfpaMylDqytW/kdmB3ZGs=",
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "24fed06cac83bcc44ac8efbb57cab1a82fa0bedc",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781064232,
-        "narHash": "sha256-+7cIaqM6ucKf5fDyMnkwehxG8tBdaU51TZOMtxacXmI=",
+        "lastModified": 1781129616,
+        "narHash": "sha256-Hl0Pz/QIKpePSU7SdK3BMe5VNmUhFvfWyg57GyawxzE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1ffdc28076a1809ee7c0cf08f06af18f31c480cd",
+        "rev": "7dbd305f8b81050f223f00bcfbc8a6b74e048806",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1781068330,
-        "narHash": "sha256-f33bN9C/yAsxtabx2WW/nc0r5XfgjU5G+pHNoEKBkH0=",
+        "lastModified": 1781159650,
+        "narHash": "sha256-5FkkJww0dLP+UFQVdyUQQ4quA9566Wv6AzvJzHcOjIQ=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "2b37c8b92d0c4a1bd6c789b66fd97bd1bcd8ac87",
+        "rev": "c8c093e5a7132c0b37d77f8919ecf2e44c730503",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1781075881,
-        "narHash": "sha256-QEFOVpjH7tyBfkTApTfiLRjsRBQ/zBymB8K8xA7+A1w=",
+        "lastModified": 1781166945,
+        "narHash": "sha256-AQXVDiyDjwtMuhR+ogmbTinAkBYhsJ26b9p4BxsturI=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "a82469f21cda20faabf149acdf95d95c256d8ac0",
+        "rev": "98badaf3f2223617f464a640d80115dc932256cf",
         "type": "github"
       },
       "original": {
@@ -374,11 +374,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780795403,
-        "narHash": "sha256-AkWx4Zt9pQbD/f82Z8N57+d0HGLN/rV3gdMKJTpBPKs=",
+        "lastModified": 1781160382,
+        "narHash": "sha256-rK6/8hoDWZe64npiBEIcrJ5JLv1zBnn6HBZGbVj/nDU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6a771120d607dcccb279a27d227650e324815c35",
+        "rev": "f73cbf1f6549f1bf349398f8276801a9c1a17aa7",
         "type": "github"
       },
       "original": {
@@ -451,11 +451,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1781020964,
-        "narHash": "sha256-fS7xTi2j2iso5Hj7RNZLv/acDlCT+fgMVkVk40A7Uco=",
+        "lastModified": 1781168557,
+        "narHash": "sha256-LOnLQ2tpYF9gqIDDr3+j3DbpJJr/QCH6zPRT2GzEUOE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "32c2cd9e46286c4eced3dc6b613c659126bf3cca",
+        "rev": "6358ff76821101c178e3ab4919a62799bfe3652e",
         "type": "github"
       },
       "original": {
@@ -479,16 +479,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1751741127,
-        "narHash": "sha256-t75Shs76NgxjZSgvvZZ9qOmz5zuBE8buUaYD28BMTxg=",
+        "lastModified": 1780902259,
+        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29e290002bfff26af1db6f64d070698019460302",
+        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'attic':
    'github:zhaofengli/attic/12cbeca141f46e1ade76728bce8adc447f2166c6?narHash=sha256-0nZlCCDC5PfndsQJXXtcyrtrfW49I3KadGMDlutzaGU%3D' (2025-09-24)
  → 'github:zhaofengli/attic/295a33a1e4a5138868e6f45dc75ed68a05c0300f?narHash=sha256-I2cjqxsVyoqAKl1/egoIDV5h96ACOdf9RQZz%2B2dBvAk%3D' (2026-06-11)
• Updated input 'attic/nixpkgs-stable':
    'github:NixOS/nixpkgs/29e290002bfff26af1db6f64d070698019460302?narHash=sha256-t75Shs76NgxjZSgvvZZ9qOmz5zuBE8buUaYD28BMTxg%3D' (2025-07-05)
  → 'github:NixOS/nixpkgs/bd0ff2d3eac24699c3664d5966b9ef36f388e2ca?narHash=sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ%3D' (2026-06-08)
• Updated input 'disko':
    'github:nix-community/disko/24fed06cac83bcc44ac8efbb57cab1a82fa0bedc?narHash=sha256-c3430xwxwhHipl3jigUGMMBfpaMylDqytW/kdmB3ZGs%3D' (2026-06-08)
  → 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1?narHash=sha256-RxWs5ND31KzTG7wvMM%2BPMfUjyNpmIEr999lqNARaM5o%3D' (2026-06-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1ffdc28076a1809ee7c0cf08f06af18f31c480cd?narHash=sha256-%2B7cIaqM6ucKf5fDyMnkwehxG8tBdaU51TZOMtxacXmI%3D' (2026-06-10)
  → 'github:nix-community/home-manager/7dbd305f8b81050f223f00bcfbc8a6b74e048806?narHash=sha256-Hl0Pz/QIKpePSU7SdK3BMe5VNmUhFvfWyg57GyawxzE%3D' (2026-06-10)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/2b37c8b92d0c4a1bd6c789b66fd97bd1bcd8ac87?narHash=sha256-f33bN9C/yAsxtabx2WW/nc0r5XfgjU5G%2BpHNoEKBkH0%3D' (2026-06-10)
  → 'github:homebrew/homebrew-cask/c8c093e5a7132c0b37d77f8919ecf2e44c730503?narHash=sha256-5FkkJww0dLP%2BUFQVdyUQQ4quA9566Wv6AzvJzHcOjIQ%3D' (2026-06-11)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/a82469f21cda20faabf149acdf95d95c256d8ac0?narHash=sha256-QEFOVpjH7tyBfkTApTfiLRjsRBQ/zBymB8K8xA7%2BA1w%3D' (2026-06-10)
  → 'github:homebrew/homebrew-core/98badaf3f2223617f464a640d80115dc932256cf?narHash=sha256-AQXVDiyDjwtMuhR%2BogmbTinAkBYhsJ26b9p4BxsturI%3D' (2026-06-11)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/6a771120d607dcccb279a27d227650e324815c35?narHash=sha256-AkWx4Zt9pQbD/f82Z8N57%2Bd0HGLN/rV3gdMKJTpBPKs%3D' (2026-06-07)
  → 'github:LnL7/nix-darwin/f73cbf1f6549f1bf349398f8276801a9c1a17aa7?narHash=sha256-rK6/8hoDWZe64npiBEIcrJ5JLv1zBnn6HBZGbVj/nDU%3D' (2026-06-11)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/32c2cd9e46286c4eced3dc6b613c659126bf3cca?narHash=sha256-fS7xTi2j2iso5Hj7RNZLv/acDlCT%2BfgMVkVk40A7Uco%3D' (2026-06-09)
  → 'github:NixOS/nixos-hardware/6358ff76821101c178e3ab4919a62799bfe3652e?narHash=sha256-LOnLQ2tpYF9gqIDDr3%2Bj3DbpJJr/QCH6zPRT2GzEUOE%3D' (2026-06-11)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'