### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781129616,
-        "narHash": "sha256-Hl0Pz/QIKpePSU7SdK3BMe5VNmUhFvfWyg57GyawxzE=",
+        "lastModified": 1781189114,
+        "narHash": "sha256-5inaamLgUMWy+MOBE9ChF9QAF1o/74LFuHkI0W/9rqc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7dbd305f8b81050f223f00bcfbc8a6b74e048806",
+        "rev": "486595d2cf49cfcd649b58a284fa11ac0e34da22",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1781159650,
-        "narHash": "sha256-5FkkJww0dLP+UFQVdyUQQ4quA9566Wv6AzvJzHcOjIQ=",
+        "lastModified": 1781254567,
+        "narHash": "sha256-it/o4+WDOu3pe7OQ3ww94ORYJO+AITR5+JxqZassoUo=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "c8c093e5a7132c0b37d77f8919ecf2e44c730503",
+        "rev": "29e86a39f8441d64631e1c29e585776749794199",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1781166945,
-        "narHash": "sha256-AQXVDiyDjwtMuhR+ogmbTinAkBYhsJ26b9p4BxsturI=",
+        "lastModified": 1781254422,
+        "narHash": "sha256-gtVZnaALxHiIdjtHZ3KBLDlOg8u7nw2cCxCn7yhOvHc=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "98badaf3f2223617f464a640d80115dc932256cf",
+        "rev": "17998ef13adc3bb49d471a2dc258b70920bc5f1c",
         "type": "github"
       },
       "original": {
@@ -374,11 +374,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781160382,
-        "narHash": "sha256-rK6/8hoDWZe64npiBEIcrJ5JLv1zBnn6HBZGbVj/nDU=",
+        "lastModified": 1781242433,
+        "narHash": "sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO+E=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f73cbf1f6549f1bf349398f8276801a9c1a17aa7",
+        "rev": "aabb2037edfc0f210723b72cd5f528aab5dd3f0b",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1780492467,
-        "narHash": "sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY=",
+        "lastModified": 1781235228,
+        "narHash": "sha256-P418y4kExDPXAIeMOo9Rc60Q47kwfN1Yn6ZJ9HCFIsI=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "562332f97de9f5ba51aa647d70462e88222b2988",
+        "rev": "e3f2579efec0a263263a733b2a5665bee13e71ef",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/7dbd305f8b81050f223f00bcfbc8a6b74e048806?narHash=sha256-Hl0Pz/QIKpePSU7SdK3BMe5VNmUhFvfWyg57GyawxzE%3D' (2026-06-10)
  → 'github:nix-community/home-manager/486595d2cf49cfcd649b58a284fa11ac0e34da22?narHash=sha256-5inaamLgUMWy%2BMOBE9ChF9QAF1o/74LFuHkI0W/9rqc%3D' (2026-06-11)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/c8c093e5a7132c0b37d77f8919ecf2e44c730503?narHash=sha256-5FkkJww0dLP%2BUFQVdyUQQ4quA9566Wv6AzvJzHcOjIQ%3D' (2026-06-11)
  → 'github:homebrew/homebrew-cask/29e86a39f8441d64631e1c29e585776749794199?narHash=sha256-it/o4%2BWDOu3pe7OQ3ww94ORYJO%2BAITR5%2BJxqZassoUo%3D' (2026-06-12)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/98badaf3f2223617f464a640d80115dc932256cf?narHash=sha256-AQXVDiyDjwtMuhR%2BogmbTinAkBYhsJ26b9p4BxsturI%3D' (2026-06-11)
  → 'github:homebrew/homebrew-core/17998ef13adc3bb49d471a2dc258b70920bc5f1c?narHash=sha256-gtVZnaALxHiIdjtHZ3KBLDlOg8u7nw2cCxCn7yhOvHc%3D' (2026-06-12)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/f73cbf1f6549f1bf349398f8276801a9c1a17aa7?narHash=sha256-rK6/8hoDWZe64npiBEIcrJ5JLv1zBnn6HBZGbVj/nDU%3D' (2026-06-11)
  → 'github:LnL7/nix-darwin/aabb2037edfc0f210723b72cd5f528aab5dd3f0b?narHash=sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO%2BE%3D' (2026-06-12)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/562332f97de9f5ba51aa647d70462e88222b2988?narHash=sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY%3D' (2026-06-03)
  → 'github:zhaofengli/nix-homebrew/e3f2579efec0a263263a733b2a5665bee13e71ef?narHash=sha256-P418y4kExDPXAIeMOo9Rc60Q47kwfN1Yn6ZJ9HCFIsI%3D' (2026-06-12)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a799d3e3886da994fa307f817a6bc705ae538eeb?narHash=sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY%3D' (2026-06-06)
  → 'github:NixOS/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca?narHash=sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4%3D' (2026-06-10)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'