### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -73,16 +73,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779646357,
-        "narHash": "sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k=",
+        "lastModified": 1781226006,
+        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "10a163ac127624caa80cc5cc5a705e97f3615b0e",
+        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.14",
+        "ref": "6.0.1",
         "repo": "brew",
         "type": "github"
       }
@@ -286,11 +286,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777992933,
-        "narHash": "sha256-b+eN1E5PAQVexQ9+uDxdGrM5aGsz9hpUNuircAb0bmo=",
+        "lastModified": 1781286750,
+        "narHash": "sha256-trvhW+Z3uRS4YLV5r9Wd2MTcyFHvSsgSRF1xV6nB1kc=",
         "owner": "tailscale",
         "repo": "golink",
-        "rev": "b85eec3e0ed734380a61b31782b72818f214c494",
+        "rev": "50d56257a80c781c9cda581b284ffd2bd1847ec4",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781189114,
-        "narHash": "sha256-5inaamLgUMWy+MOBE9ChF9QAF1o/74LFuHkI0W/9rqc=",
+        "lastModified": 1781305496,
+        "narHash": "sha256-g8Vv4Qfc7n+lgov97REu3X6BeJtvYY0hlSUZR1GrGQQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "486595d2cf49cfcd649b58a284fa11ac0e34da22",
+        "rev": "c87a39aa979acc4848016d2220c6238390d84779",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1781254567,
-        "narHash": "sha256-it/o4+WDOu3pe7OQ3ww94ORYJO+AITR5+JxqZassoUo=",
+        "lastModified": 1781338640,
+        "narHash": "sha256-h/r1tEuiz3dHDOvyYN/u/QF1v45d+/9F7EF8qU9/Pn0=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "29e86a39f8441d64631e1c29e585776749794199",
+        "rev": "47cd03ff844680649dcb16810157f6503f516ef4",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1781254422,
-        "narHash": "sha256-gtVZnaALxHiIdjtHZ3KBLDlOg8u7nw2cCxCn7yhOvHc=",
+        "lastModified": 1781335664,
+        "narHash": "sha256-5NE5h9ADVd19K6W3jZRpBEKcJFK1Y/T73+p3ZJJS+xo=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "17998ef13adc3bb49d471a2dc258b70920bc5f1c",
+        "rev": "b143370a08f0d0327b7db747f77c3efbef8e863a",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1781235228,
-        "narHash": "sha256-P418y4kExDPXAIeMOo9Rc60Q47kwfN1Yn6ZJ9HCFIsI=",
+        "lastModified": 1781269551,
+        "narHash": "sha256-zn0rty4K5LbBAzuyJMdncDbYzSefr29IUJvcUv7kFn8=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "e3f2579efec0a263263a733b2a5665bee13e71ef",
+        "rev": "5e721fc7756a6abffe07c7dd5ed3f9080b68108f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'golink':
    'github:tailscale/golink/b85eec3e0ed734380a61b31782b72818f214c494?narHash=sha256-b%2BeN1E5PAQVexQ9%2BuDxdGrM5aGsz9hpUNuircAb0bmo%3D' (2026-05-05)
  → 'github:tailscale/golink/50d56257a80c781c9cda581b284ffd2bd1847ec4?narHash=sha256-trvhW%2BZ3uRS4YLV5r9Wd2MTcyFHvSsgSRF1xV6nB1kc%3D' (2026-06-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/486595d2cf49cfcd649b58a284fa11ac0e34da22?narHash=sha256-5inaamLgUMWy%2BMOBE9ChF9QAF1o/74LFuHkI0W/9rqc%3D' (2026-06-11)
  → 'github:nix-community/home-manager/c87a39aa979acc4848016d2220c6238390d84779?narHash=sha256-g8Vv4Qfc7n%2Blgov97REu3X6BeJtvYY0hlSUZR1GrGQQ%3D' (2026-06-12)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/29e86a39f8441d64631e1c29e585776749794199?narHash=sha256-it/o4%2BWDOu3pe7OQ3ww94ORYJO%2BAITR5%2BJxqZassoUo%3D' (2026-06-12)
  → 'github:homebrew/homebrew-cask/47cd03ff844680649dcb16810157f6503f516ef4?narHash=sha256-h/r1tEuiz3dHDOvyYN/u/QF1v45d%2B/9F7EF8qU9/Pn0%3D' (2026-06-13)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/17998ef13adc3bb49d471a2dc258b70920bc5f1c?narHash=sha256-gtVZnaALxHiIdjtHZ3KBLDlOg8u7nw2cCxCn7yhOvHc%3D' (2026-06-12)
  → 'github:homebrew/homebrew-core/b143370a08f0d0327b7db747f77c3efbef8e863a?narHash=sha256-5NE5h9ADVd19K6W3jZRpBEKcJFK1Y/T73%2Bp3ZJJS%2Bxo%3D' (2026-06-13)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/e3f2579efec0a263263a733b2a5665bee13e71ef?narHash=sha256-P418y4kExDPXAIeMOo9Rc60Q47kwfN1Yn6ZJ9HCFIsI%3D' (2026-06-12)
  → 'github:zhaofengli/nix-homebrew/5e721fc7756a6abffe07c7dd5ed3f9080b68108f?narHash=sha256-zn0rty4K5LbBAzuyJMdncDbYzSefr29IUJvcUv7kFn8%3D' (2026-06-12)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/10a163ac127624caa80cc5cc5a705e97f3615b0e?narHash=sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k%3D' (2026-05-24)
  → 'github:Homebrew/brew/109191be4988470b51a60a5ef1998520aa24c01b?narHash=sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y%3D' (2026-06-12)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'