### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1781150914,
-        "narHash": "sha256-I2cjqxsVyoqAKl1/egoIDV5h96ACOdf9RQZz+2dBvAk=",
+        "lastModified": 1781405577,
+        "narHash": "sha256-sboz+gG8z0KX+q0kkvLloNcogXYLwiY5iw2xwN36rFo=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "295a33a1e4a5138868e6f45dc75ed68a05c0300f",
+        "rev": "6b22d76ca351c5a07a5e5a60b95bc23320f7e791",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781305496,
-        "narHash": "sha256-g8Vv4Qfc7n+lgov97REu3X6BeJtvYY0hlSUZR1GrGQQ=",
+        "lastModified": 1781365335,
+        "narHash": "sha256-zqDBhXMzfbdlO7F2bGHe7MOtB3xngd/+4ieMHDC+ZXo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c87a39aa979acc4848016d2220c6238390d84779",
+        "rev": "5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1781338640,
-        "narHash": "sha256-h/r1tEuiz3dHDOvyYN/u/QF1v45d+/9F7EF8qU9/Pn0=",
+        "lastModified": 1781423506,
+        "narHash": "sha256-t83+8uVySDEZrLbfjlpBpFXBS627S+/bBC4bBIjMb2c=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "47cd03ff844680649dcb16810157f6503f516ef4",
+        "rev": "2fd82a7f04972ca91e1d69e06ddde48e6acf63f1",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1781335664,
-        "narHash": "sha256-5NE5h9ADVd19K6W3jZRpBEKcJFK1Y/T73+p3ZJJS+xo=",
+        "lastModified": 1781417416,
+        "narHash": "sha256-BhGPZJ2fCvwThidTHyBN0Y9mqfBvpoM2owFUwPc6q6Y=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "b143370a08f0d0327b7db747f77c3efbef8e863a",
+        "rev": "c177cfe52f1a725feb7ce391e5654995e2dcc061",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1781269551,
-        "narHash": "sha256-zn0rty4K5LbBAzuyJMdncDbYzSefr29IUJvcUv7kFn8=",
+        "lastModified": 1781389246,
+        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "5e721fc7756a6abffe07c7dd5ed3f9080b68108f",
+        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780816331,
-        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
+        "lastModified": 1781422160,
+        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
+        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'attic':
    'github:zhaofengli/attic/295a33a1e4a5138868e6f45dc75ed68a05c0300f?narHash=sha256-I2cjqxsVyoqAKl1/egoIDV5h96ACOdf9RQZz%2B2dBvAk%3D' (2026-06-11)
  → 'github:zhaofengli/attic/6b22d76ca351c5a07a5e5a60b95bc23320f7e791?narHash=sha256-sboz%2BgG8z0KX%2Bq0kkvLloNcogXYLwiY5iw2xwN36rFo%3D' (2026-06-14)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c87a39aa979acc4848016d2220c6238390d84779?narHash=sha256-g8Vv4Qfc7n%2Blgov97REu3X6BeJtvYY0hlSUZR1GrGQQ%3D' (2026-06-12)
  → 'github:nix-community/home-manager/5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c?narHash=sha256-zqDBhXMzfbdlO7F2bGHe7MOtB3xngd/%2B4ieMHDC%2BZXo%3D' (2026-06-13)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/47cd03ff844680649dcb16810157f6503f516ef4?narHash=sha256-h/r1tEuiz3dHDOvyYN/u/QF1v45d%2B/9F7EF8qU9/Pn0%3D' (2026-06-13)
  → 'github:homebrew/homebrew-cask/2fd82a7f04972ca91e1d69e06ddde48e6acf63f1?narHash=sha256-t83%2B8uVySDEZrLbfjlpBpFXBS627S%2B/bBC4bBIjMb2c%3D' (2026-06-14)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/b143370a08f0d0327b7db747f77c3efbef8e863a?narHash=sha256-5NE5h9ADVd19K6W3jZRpBEKcJFK1Y/T73%2Bp3ZJJS%2Bxo%3D' (2026-06-13)
  → 'github:homebrew/homebrew-core/c177cfe52f1a725feb7ce391e5654995e2dcc061?narHash=sha256-BhGPZJ2fCvwThidTHyBN0Y9mqfBvpoM2owFUwPc6q6Y%3D' (2026-06-14)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/5e721fc7756a6abffe07c7dd5ed3f9080b68108f?narHash=sha256-zn0rty4K5LbBAzuyJMdncDbYzSefr29IUJvcUv7kFn8%3D' (2026-06-12)
  → 'github:zhaofengli/nix-homebrew/de7953a08ed4bb9245be043e468561c17b89130d?narHash=sha256-ORqLAo/hoJdsZC7UPAuEHev6S0%2BXIqKEC7vjo5prz1k%3D' (2026-06-13)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/1a2ea89c917781e88508d9fd2b507f2d2a0e173c?narHash=sha256-0BYqs8yKWkOz2Q7%2BSP18N5E5gmDKSo6LSxIVIa0wWes%3D' (2026-06-07)
  → 'github:nix-community/nix-index-database/854d04e2368fb2e9c328a36b3c0a04cd713bfae1?narHash=sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0%3D' (2026-06-14)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'