### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -111,11 +111,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1781023725,
-        "narHash": "sha256-Gt+qFANcrDRjl3xzidLYrAUQCd3808iuAsLwZbYYAEU=",
+        "lastModified": 1781627888,
+        "narHash": "sha256-5yHuAh9k7rT7rtf3uRaXkiUyYvQE9oaCgzhprLm2mr8=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "2ce9051767ee4d1a3c43b52ba327431783bfd463",
+        "rev": "6d3087eedff75a715b40c0e124ba15d2dd7bec28",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781557312,
-        "narHash": "sha256-QOIRYSUFSq7L5mY3dZymaVhcnne3tPgoR9riB0WocjA=",
+        "lastModified": 1782166451,
+        "narHash": "sha256-SA7LyrayyZBvtzZnesnSLV7haciFuVLeZaX2hd5v4j4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c03e4752899e55705dfa63979abd885c582a5c48",
+        "rev": "471a1d2f840eb7fcbdfd541d99c13a64096f46db",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1781604438,
-        "narHash": "sha256-uVi2/3E7RJqtRbZDPIgZ2T9iyhTU4hAQpM4J0pDmxNM=",
+        "lastModified": 1782203340,
+        "narHash": "sha256-KNVJ7Y9rGGmW+80hEo9DPDGNLeZxrQvRSZCvZ5eO/4Y=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "fb3b86c807af7c8064d7ae28e2f6db3f7b9c72ba",
+        "rev": "cc2299827873991240ee217285b3678868b55195",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1781604599,
-        "narHash": "sha256-tvaTZobHphV/FzrR2k4iOFzi6bFgwn7ZfZ81YHCav0s=",
+        "lastModified": 1782201521,
+        "narHash": "sha256-dSfdR4QH9YnGimm7lj9SEepY+zi+bhf+zM8GUv8pSCw=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "42948475bc76ddbb473a2d72bffb9d2265d813e3",
+        "rev": "9f4023e7dce609cec467ab3441abfc0be7ed0649",
         "type": "github"
       },
       "original": {
@@ -374,11 +374,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781242433,
-        "narHash": "sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO+E=",
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "aabb2037edfc0f210723b72cd5f528aab5dd3f0b",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781422160,
-        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
+        "lastModified": 1782030356,
+        "narHash": "sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
+        "rev": "3017088b49efd404f78e3b104f553b97e4af786b",
         "type": "github"
       },
       "original": {
@@ -451,11 +451,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1781168557,
-        "narHash": "sha256-LOnLQ2tpYF9gqIDDr3+j3DbpJJr/QCH6zPRT2GzEUOE=",
+        "lastModified": 1782166108,
+        "narHash": "sha256-/EtnQBcKbsaCAGQ5VRcplrHRkR4ryqyLMpBfkVuG9Xw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6358ff76821101c178e3ab4919a62799bfe3652e",
+        "rev": "875776f0252fcb8618bb948640a0d1f7a5b362be",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'deploy-rs':
    'github:serokell/deploy-rs/2ce9051767ee4d1a3c43b52ba327431783bfd463?narHash=sha256-Gt%2BqFANcrDRjl3xzidLYrAUQCd3808iuAsLwZbYYAEU%3D' (2026-06-09)
  → 'github:serokell/deploy-rs/6d3087eedff75a715b40c0e124ba15d2dd7bec28?narHash=sha256-5yHuAh9k7rT7rtf3uRaXkiUyYvQE9oaCgzhprLm2mr8%3D' (2026-06-16)
• Updated input 'git-hooks-nix':
    'github:cachix/git-hooks.nix/61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a?narHash=sha256-kTwur1wV%2B01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs%3D' (2026-05-11)
  → 'github:cachix/git-hooks.nix/3bbec39bc90eadfa031e6f3b77272f3f60803e39?narHash=sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco%2B3u0%3D' (2026-06-17)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c03e4752899e55705dfa63979abd885c582a5c48?narHash=sha256-QOIRYSUFSq7L5mY3dZymaVhcnne3tPgoR9riB0WocjA%3D' (2026-06-15)
  → 'github:nix-community/home-manager/471a1d2f840eb7fcbdfd541d99c13a64096f46db?narHash=sha256-SA7LyrayyZBvtzZnesnSLV7haciFuVLeZaX2hd5v4j4%3D' (2026-06-22)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/fb3b86c807af7c8064d7ae28e2f6db3f7b9c72ba?narHash=sha256-uVi2/3E7RJqtRbZDPIgZ2T9iyhTU4hAQpM4J0pDmxNM%3D' (2026-06-16)
  → 'github:homebrew/homebrew-cask/cc2299827873991240ee217285b3678868b55195?narHash=sha256-KNVJ7Y9rGGmW%2B80hEo9DPDGNLeZxrQvRSZCvZ5eO/4Y%3D' (2026-06-23)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/42948475bc76ddbb473a2d72bffb9d2265d813e3?narHash=sha256-tvaTZobHphV/FzrR2k4iOFzi6bFgwn7ZfZ81YHCav0s%3D' (2026-06-16)
  → 'github:homebrew/homebrew-core/9f4023e7dce609cec467ab3441abfc0be7ed0649?narHash=sha256-dSfdR4QH9YnGimm7lj9SEepY%2Bzi%2Bbhf%2BzM8GUv8pSCw%3D' (2026-06-23)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/aabb2037edfc0f210723b72cd5f528aab5dd3f0b?narHash=sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO%2BE%3D' (2026-06-12)
  → 'github:LnL7/nix-darwin/a1fa429e945becaf60468600daf649be4ba0350c?narHash=sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14%3D' (2026-06-18)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/854d04e2368fb2e9c328a36b3c0a04cd713bfae1?narHash=sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0%3D' (2026-06-14)
  → 'github:nix-community/nix-index-database/3017088b49efd404f78e3b104f553b97e4af786b?narHash=sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4%3D' (2026-06-21)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/6358ff76821101c178e3ab4919a62799bfe3652e?narHash=sha256-LOnLQ2tpYF9gqIDDr3%2Bj3DbpJJr/QCH6zPRT2GzEUOE%3D' (2026-06-11)
  → 'github:NixOS/nixos-hardware/875776f0252fcb8618bb948640a0d1f7a5b362be?narHash=sha256-/EtnQBcKbsaCAGQ5VRcplrHRkR4ryqyLMpBfkVuG9Xw%3D' (2026-06-22)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9ae611a455b90cf061d8f332b977e387bda8e1ca?narHash=sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4%3D' (2026-06-10)
  → 'github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f?narHash=sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H%2BCNW1Ck8B%2B8%3D' (2026-06-16)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'