### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1781405577,
-        "narHash": "sha256-sboz+gG8z0KX+q0kkvLloNcogXYLwiY5iw2xwN36rFo=",
+        "lastModified": 1782346752,
+        "narHash": "sha256-bP40Va8k28byE5Fm3z+wPpSjT3v5a4gZpnDAfLCfrE8=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "6b22d76ca351c5a07a5e5a60b95bc23320f7e791",
+        "rev": "3d5abb7153f6bbaee4d95af7b6b1e8a0cc400906",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1751562746,
-        "narHash": "sha256-smpugNIkmDeicNz301Ll1bD7nFOty97T79m4GUMUczA=",
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "aed2020fd3dc26e1e857d4107a5a67a33ab6c1fd",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782233665,
-        "narHash": "sha256-h/xOtrByoA/Ak1lWHn0O1lVZz4qWYbwOSLQ8YSwQO0I=",
+        "lastModified": 1782358560,
+        "narHash": "sha256-vCcLh9pw3XO/+Lxk8r6xv6QnoCrTfGqiACcI7O637Wg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "062581938b4a378a82dfbb294b494808157153a1",
+        "rev": "3a70e333f2950c302e875c44cfcfaff3f80f36bc",
         "type": "github"
       },
       "original": {
@@ -322,11 +322,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1782288577,
-        "narHash": "sha256-tDfaErznl1pnGSuxCg52dnYc7/b+tKnPMrsqJwOTbiM=",
+        "lastModified": 1782373683,
+        "narHash": "sha256-t6IDo6uT8qPiX0SptkUcyMKKlPkcqaDw6sSk8NzSjs4=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "e6016f0f395695c772249d2637d2502dbacee371",
+        "rev": "c7201d0d820f7ede5c122d4fde3e91c71c155fba",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1782286252,
-        "narHash": "sha256-DO8dy7pnH1lVB8wZLwayuyHWnDX1OP4ud6TA0zgLxYc=",
+        "lastModified": 1782374936,
+        "narHash": "sha256-Y2jIrL0i7IaiNzfHbX7Bhz4ZEpjtPMhAjluMK2rkY0c=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "692d933e202436874f138cb35234506a1bb94fc6",
+        "rev": "6098ff9ebca16b8a9cfd04289a14a97b8b48a092",
         "type": "github"
       },
       "original": {
@@ -479,11 +479,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1780902259,
-        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
+        "lastModified": 1782116945,
+        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'attic':
    'github:zhaofengli/attic/6b22d76ca351c5a07a5e5a60b95bc23320f7e791?narHash=sha256-sboz%2BgG8z0KX%2Bq0kkvLloNcogXYLwiY5iw2xwN36rFo%3D' (2026-06-14)
  → 'github:zhaofengli/attic/3d5abb7153f6bbaee4d95af7b6b1e8a0cc400906?narHash=sha256-bP40Va8k28byE5Fm3z%2BwPpSjT3v5a4gZpnDAfLCfrE8%3D' (2026-06-25)
• Updated input 'attic/crane':
    'github:ipetkov/crane/aed2020fd3dc26e1e857d4107a5a67a33ab6c1fd?narHash=sha256-smpugNIkmDeicNz301Ll1bD7nFOty97T79m4GUMUczA%3D' (2025-07-03)
  → 'github:ipetkov/crane/469fd08d0bcf6926321fa973c6777fbc87785dd7?narHash=sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk%3D' (2026-06-18)
• Updated input 'attic/flake-compat':
    'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
  → 'github:edolstra/flake-compat/5edf11c44bc78a0d334f6334cdaf7d60d732daab?narHash=sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns%3D' (2025-12-29)
• Updated input 'attic/flake-parts':
    'github:hercules-ci/flake-parts/77826244401ea9de6e3bac47c2db46005e1f30b5?narHash=sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ%3D' (2025-07-01)
  → 'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
• Updated input 'attic/nixpkgs-stable':
    'github:NixOS/nixpkgs/bd0ff2d3eac24699c3664d5966b9ef36f388e2ca?narHash=sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ%3D' (2026-06-08)
  → 'github:NixOS/nixpkgs/34268251cf5547d39063f2c5ea9a196246f7f3a6?narHash=sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX%2BBLuJDpE8hz0Ds%3D' (2026-06-22)
• Updated input 'home-manager':
    'github:nix-community/home-manager/062581938b4a378a82dfbb294b494808157153a1?narHash=sha256-h/xOtrByoA/Ak1lWHn0O1lVZz4qWYbwOSLQ8YSwQO0I%3D' (2026-06-23)
  → 'github:nix-community/home-manager/3a70e333f2950c302e875c44cfcfaff3f80f36bc?narHash=sha256-vCcLh9pw3XO/%2BLxk8r6xv6QnoCrTfGqiACcI7O637Wg%3D' (2026-06-25)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/e6016f0f395695c772249d2637d2502dbacee371?narHash=sha256-tDfaErznl1pnGSuxCg52dnYc7/b%2BtKnPMrsqJwOTbiM%3D' (2026-06-24)
  → 'github:homebrew/homebrew-cask/c7201d0d820f7ede5c122d4fde3e91c71c155fba?narHash=sha256-t6IDo6uT8qPiX0SptkUcyMKKlPkcqaDw6sSk8NzSjs4%3D' (2026-06-25)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/692d933e202436874f138cb35234506a1bb94fc6?narHash=sha256-DO8dy7pnH1lVB8wZLwayuyHWnDX1OP4ud6TA0zgLxYc%3D' (2026-06-24)
  → 'github:homebrew/homebrew-core/6098ff9ebca16b8a9cfd04289a14a97b8b48a092?narHash=sha256-Y2jIrL0i7IaiNzfHbX7Bhz4ZEpjtPMhAjluMK2rkY0c%3D' (2026-06-25)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'