### PR TITLE
spore: update static IP after CloudCone reassignment

### DIFF
--- a/hosts/spore/default.nix
+++ b/hosts/spore/default.nix
@@ -23,13 +23,14 @@
       useDHCP = false;
       ipv4.addresses = [
         {
-          address = "74.48.202.251";
+          # CloudCone reassigned the VPS public IP (was 74.48.202.251/24).
+          address = "182.255.82.149";
           prefixLength = 24;
         }
       ];
     };
     defaultGateway = {
-      address = "74.48.202.1";
+      address = "182.255.82.1";
       interface = "eth0";
     };
     nameservers = ["8.8.8.8"];


### PR DESCRIPTION
CloudCone reassigned spore's public IP from 74.48.202.251/24 (gw 74.48.202.1) to 182.255.82.149/24 (gw 182.255.82.1). Every generation baked in the old address, so on boot spore assigned itself a dead IP on the wrong subnet and became unreachable while still booting to a login prompt (VNC), matching the observed symptom.