### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784690067,
-        "narHash": "sha256-t86pRs7IPs3RTMPueWvvdcxyTFrctHAv2Jl7jnjsSf8=",
+        "lastModified": 1784789275,
+        "narHash": "sha256-cgRTWuG+u1tBPhm01JrId2k0Bni09phVJ1Q0BZlRd7M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6d8d61567802997f9ec3086b2a837e3ef31fac16",
+        "rev": "3b0e6bbd65869af1beadf5963a99befc179d209f",
         "type": "github"
       },
       "original": {
@@ -298,11 +298,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1784703249,
-        "narHash": "sha256-7C+7gDApeb7JG4VXI7v0ZqiYnBRJhbqbY1Y2OI6cPxk=",
+        "lastModified": 1784785367,
+        "narHash": "sha256-5Iuc+98EI5+gz9StEagqzwYaVkmtb9h1V7YzOipLKhc=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "8d2d5a15f538c047d51b36055b14d53db8ef3cf4",
+        "rev": "45658406e9109543c11041e3dc0b696c2e804101",
         "type": "github"
       },
       "original": {
@@ -314,11 +314,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1784703172,
-        "narHash": "sha256-opJtiqzzMqguYiEiTmV5dI15jeEX8h5YXLA4QbhI9nQ=",
+        "lastModified": 1784789358,
+        "narHash": "sha256-ZtA7bmAyX0NKR3yO7Pe5E9rka1EWbCuQcjKn/rree8E=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "6ae532c820ba2691464b92eb3e27f79f676c69b0",
+        "rev": "76c525d4aca67de44e8c5c320ec9b90360beb73d",
         "type": "github"
       },
       "original": {
@@ -427,11 +427,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1784310968,
-        "narHash": "sha256-rkSPTePrKqs4dg+i7ZFCq93+HrClac6oSwXX927SVjA=",
+        "lastModified": 1784723954,
+        "narHash": "sha256-1CfD8ZUjCkTgjsneLZ/lxCHhgDfqxxE7/GX0MmsgiqA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "779c32a00155994c86cde8213a8dd4df139d4355",
+        "rev": "a017f5b72210026af5b3ac5949f08d94380a6fbd",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784555310,
-        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
+        "lastModified": 1782175435,
+        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
+        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'attic/nixpkgs':
    'github:NixOS/nixpkgs/421eebfd0ec7bccd4abe826ce62d7e6e83129493?narHash=sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl%2BHHZ%2BDrtM%3D' (2026-07-20)
  → 'github:NixOS/nixpkgs/89570f24e97e614aa34aa9ab1c927b6578a43775?narHash=sha256-EMzXKmnOtBQ2MnvpiNOm7E%2BkOMvdPrIKaeg52Tip2Uk%3D' (2026-06-23)
• Updated input 'home-manager':
    'github:nix-community/home-manager/6d8d61567802997f9ec3086b2a837e3ef31fac16?narHash=sha256-t86pRs7IPs3RTMPueWvvdcxyTFrctHAv2Jl7jnjsSf8%3D' (2026-07-22)
  → 'github:nix-community/home-manager/3b0e6bbd65869af1beadf5963a99befc179d209f?narHash=sha256-cgRTWuG%2Bu1tBPhm01JrId2k0Bni09phVJ1Q0BZlRd7M%3D' (2026-07-23)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/8d2d5a15f538c047d51b36055b14d53db8ef3cf4?narHash=sha256-7C%2B7gDApeb7JG4VXI7v0ZqiYnBRJhbqbY1Y2OI6cPxk%3D' (2026-07-22)
  → 'github:homebrew/homebrew-cask/45658406e9109543c11041e3dc0b696c2e804101?narHash=sha256-5Iuc%2B98EI5%2Bgz9StEagqzwYaVkmtb9h1V7YzOipLKhc%3D' (2026-07-23)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/6ae532c820ba2691464b92eb3e27f79f676c69b0?narHash=sha256-opJtiqzzMqguYiEiTmV5dI15jeEX8h5YXLA4QbhI9nQ%3D' (2026-07-22)
  → 'github:homebrew/homebrew-core/76c525d4aca67de44e8c5c320ec9b90360beb73d?narHash=sha256-ZtA7bmAyX0NKR3yO7Pe5E9rka1EWbCuQcjKn/rree8E%3D' (2026-07-23)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/779c32a00155994c86cde8213a8dd4df139d4355?narHash=sha256-rkSPTePrKqs4dg%2Bi7ZFCq93%2BHrClac6oSwXX927SVjA%3D' (2026-07-17)
  → 'github:NixOS/nixos-hardware/a017f5b72210026af5b3ac5949f08d94380a6fbd?narHash=sha256-1CfD8ZUjCkTgjsneLZ/lxCHhgDfqxxE7/GX0MmsgiqA%3D' (2026-07-22)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'