### PR TITLE
feat: enable navidrome on glyph

### DIFF
--- a/hosts/glyph/secrets/navidrome-env.age
+++ b/hosts/glyph/secrets/navidrome-env.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 rSr+rA G59mwm0s8J7IjOdA3bg+u7/khONss0qNTenWOIUGVGQ
+0DDeAzt5iLOTRsH35ajUZdEhXb2wKcDpurDrLIxWAf4
+-> ssh-ed25519 3EWhnQ UeouypZwC0npSNaIvPTVcEHBRFzeY8Fto/lQRKtBRBw
+qe9nYlHYVxIiHZgs9WNmn+N675R5+g5ureimnW3v8ss
+--- XesUDgqqbDcNT0jR4VhXhHHp0RzP6GiQBjiiE5/sF0w
+A8сТ!A` ·┤%╚:cПs%T═ж№аZC%К╓3;╬п¤}#├иО╬Ё╥4У╦║╕N┤^&п╩kх"/Нqр╨┬╙Ю3ХT $П$Г╡|о#u╩PЖ+\МMB█╒=С4	О{Эоб∙╧(├╪5Заc.С╜:неc;Єт3@╬

--- a/hosts/glyph/services/default.nix
+++ b/hosts/glyph/services/default.nix
@@ -13,6 +13,7 @@
     ./filebrowser.nix
     ./jellyfin.nix
     ./loki.nix
+    ./navidrome.nix
     ./nfs.nix
     ./ntfy.nix
     ./open-terminal.nix

--- a/hosts/glyph/services/navidrome.nix
+++ b/hosts/glyph/services/navidrome.nix
@@ -15,6 +15,7 @@
       Address = "0.0.0.0";
       MusicFolder = "/mnt/media/Music";
       Scanner.Schedule = "@every 1h";
+      RecentlyAddedByModTime = true;
     };
   };
 }

--- a/hosts/glyph/services/navidrome.nix
+++ b/hosts/glyph/services/navidrome.nix
@@ -1,0 +1,20 @@
+{config, ...}: {
+  age.secrets.navidrome-env = {
+    file = ./../secrets/navidrome-env.age;
+    mode = "440";
+    owner = config.services.navidrome.user;
+    group = config.services.navidrome.group;
+  };
+
+  services.navidrome = {
+    enable = true;
+    openFirewall = true;
+    group = "media";
+    environmentFile = config.age.secrets.navidrome-env.path;
+    settings = {
+      Address = "0.0.0.0";
+      MusicFolder = "/mnt/media/Music";
+      Scanner.Schedule = "@every 1h";
+    };
+  };
+}

--- a/lib/secrets/glyph.nix
+++ b/lib/secrets/glyph.nix
@@ -13,4 +13,5 @@ in {
   "hosts/glyph/secrets/attic-credentials.age".publicKeys = keys;
   "hosts/glyph/secrets/user-password.age".publicKeys = keys;
   "hosts/glyph/secrets/obsidian-auth-token.age".publicKeys = keys;
+  "hosts/glyph/secrets/navidrome-env.age".publicKeys = keys;
 }


### PR DESCRIPTION
## Summary
- Enable Navidrome (music streaming server) on glyph, alongside the existing jellyfin service
- Library points at `/mnt/media/Music`, bound to `0.0.0.0` and firewall-opened so it's reachable over Tailscale, matching jellyfin's setup
- Hourly `Scanner.Schedule` for periodic rescans (music files land via transmission into `/mnt/media/Unsorted`, so relying only on the inotify watcher isn't sufficient)
- LastFM scrobbling wired up via a new `hosts/glyph/secrets/navidrome-env.age` agenix secret (`ND_LASTFM_APIKEY`/`ND_LASTFM_SECRET`), registered in `lib/secrets/glyph.nix`

## Test plan
- [x] `nix-flake eval nixosConfigurations.glyph.config.system.build.toplevel.drvPath` evaluates cleanly
- [x] `nix fmt .` passes (alejandra/nil/statix)
- [x] Deploy to glyph (`nh os switch .#glyph`) and confirm Navidrome starts and scans `/mnt/media/Music`
- [x] Link LastFM account from Navidrome's Personal Settings and confirm a scrobble appears on last.fm