### PR TITLE
feat: add music.zx.dev vhost for navidrome

### DIFF
--- a/hosts/spore/services/web/default.nix
+++ b/hosts/spore/services/web/default.nix
@@ -126,6 +126,11 @@
         useACMEHost = "zx.dev";
         locations."/".proxyPass = "http://glyph.note-iwato.ts.net:8096";
       };
+      "music.zx.dev" = {
+        forceSSL = true;
+        useACMEHost = "zx.dev";
+        locations."/".proxyPass = "http://glyph.note-iwato.ts.net:4533";
+      };
       "mcp.zx.dev" = {
         forceSSL = true;
         useACMEHost = "zx.dev";


### PR DESCRIPTION
## Summary
- Adds `music.zx.dev` nginx vhost on spore, reverse-proxying to `glyph.note-iwato.ts.net:4533` (Navidrome, added in #523)
- Mirrors the `jellyfin.zx.dev` vhost pattern — no `requireAuth`, since Navidrome has its own built-in user auth

Stacked on #523 — merge that first.

## Test plan
- [x] `nix-flake eval nixosConfigurations.spore.config.system.build.toplevel.drvPath` evaluates cleanly
- [x] `nix fmt .` passes (alejandra/nil/statix)
- [x] Deploy to spore and confirm `https://music.zx.dev` proxies to Navidrome