### PR TITLE
fix: glyph beets ignore m3u/m3u8

### DIFF
--- a/hosts/glyph/home.nix
+++ b/hosts/glyph/home.nix
@@ -33,6 +33,15 @@
     enable = true;
     settings = {
       directory = "/mnt/media/Music";
+      # Extend beets' default ignore list to skip playlist files on import
+      ignore = [
+        ".*"
+        "*~"
+        "System Volume Information"
+        "lost+found"
+        "*.m3u"
+        "*.m3u8"
+      ];
       import = {
         copy = true;
         move = false;


### PR DESCRIPTION
## Summary
- Add `.m3u`/`.m3u8` to beets' `ignore` glob list on `glyph` so future imports don't copy ripper-generated playlist files into the library, where Navidrome then auto-imports them as spurious playlists.
- Preserves beets' built-in default ignores (`.*`, `*~`, `System Volume Information`, `lost+found`) since setting `ignore` replaces rather than extends the default.

## Test plan
- [x] `nix-flake eval nixosConfigurations.glyph.config.system.build.toplevel.drvPath` evaluates cleanly
- [x] `nix fmt .` passes (alejandra, nil, statix)
- [x] Deploy to glyph (`nh os switch .#glyph`) and confirm a subsequent `beet import` skips `.m3u`/`.m3u8` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)