### PR TITLE
feat(glyph): enable music-assistant

### DIFF
--- a/hosts/glyph/services/default.nix
+++ b/hosts/glyph/services/default.nix
@@ -13,6 +13,7 @@
     ./filebrowser.nix
     ./jellyfin.nix
     ./loki.nix
+    ./music-assistant.nix
     ./navidrome.nix
     ./nfs.nix
     ./ntfy.nix
@@ -127,6 +128,7 @@
   };
   services.grafana-mcp = {
     enable = true;
+    port = 8096;
     grafanaUrl = "https://grafana.zx.dev";
     tokenFile = config.age.secrets.grafana-mcp-token.path;
   };
@@ -136,6 +138,7 @@
   };
   services.obsidian-vault-mcp = {
     enable = true;
+    port = 8098;
     inherit (config.rc.obsidian-sync) vaultPath;
   };
   services.mcpjungle = {
@@ -153,7 +156,7 @@
       description = "Kagi web search and page summarization";
     };
     servers.grafana = {
-      url = "http://127.0.0.1:8095/mcp";
+      url = "http://127.0.0.1:8096/mcp";
       description = "Grafana dashboards, Loki logs, and Prometheus metrics";
     };
     servers.graphite = {
@@ -161,7 +164,7 @@
       description = "Graphite CLI for stacked PRs and code review";
     };
     servers.obsidian-vault = {
-      url = "http://127.0.0.1:8097/mcp";
+      url = "http://127.0.0.1:8098/mcp";
       description = "Read and write files in the Obsidian vault";
     };
     servers.context7 = {

--- a/hosts/glyph/services/music-assistant.nix
+++ b/hosts/glyph/services/music-assistant.nix
@@ -1,0 +1,12 @@
+_: {
+  services.music-assistant = {
+    enable = true;
+    openFirewall = true;
+    providers = [
+      "opensubsonic" # Navidrome integration
+      "airplay"
+      "musicbrainz"
+      "coverartarchive"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- Enables `services.music-assistant` on glyph with `opensubsonic` (Navidrome), `airplay`, `musicbrainz`, and `coverartarchive` providers
- Moves `grafana-mcp` from port 8095 → 8096 and `obsidian-vault-mcp` from port 8097 → 8098 to free those ports for Music Assistant's defaults
- Updates MCPJungle aggregator URLs to match the new MCP ports

## Why the MCP ports moved

Music Assistant's web UI defaults to **8095** and its audio stream port to **8097** (derived as `web_port + 2`). Both of these collided with existing localhost MCP services:

- `grafana-mcp` was on 8095
- `obsidian-vault-mcp` was on 8097

The nixpkgs `services.music-assistant` module has no `port` option — the only escape hatch is passing `--port` via `extraOptions`. However, the module's `openFirewall` implementation hardcodes 8097 unconditionally regardless of what `--port` is passed, so changing MA's port would mean `openFirewall = true` opens the wrong port and misses the actual stream port. That would require `openFirewall = false` plus manual firewall rules, adding complexity for no real benefit.

Moving the two MCP services by one port each (8095→8096, 8097→8098) is the cleaner fix: MA runs on its standard ports, `openFirewall = true` works correctly, and the MCP services remain localhost-only so nothing external is affected.

## Test plan

- [ ] Deploy to glyph: `nh os switch .#glyph`
- [ ] Music Assistant web UI reachable at `http://glyph:8095`
- [ ] Configure Navidrome as an OpenSubsonic source in the MA UI (URL: `http://localhost:4533`)
- [ ] Verify grafana-mcp still reachable by MCPJungle: `curl http://localhost:8096/mcp`
- [ ] Verify obsidian-vault-mcp still reachable: `curl http://localhost:8098/mcp`
- [ ] Verify Open WebUI MCP tools still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)