### PR TITLE
feat(spore): add ma.zx.dev for music-assistant

### DIFF
--- a/hosts/spore/services/web/default.nix
+++ b/hosts/spore/services/web/default.nix
@@ -131,6 +131,14 @@
         useACMEHost = "zx.dev";
         locations."/".proxyPass = "http://glyph.note-iwato.ts.net:4533";
       };
+      "ma.zx.dev" = {
+        forceSSL = true;
+        useACMEHost = "zx.dev";
+        locations."/" = {
+          proxyPass = "http://glyph.note-iwato.ts.net:8095";
+          proxyWebsockets = true;
+        };
+      };
       "mcp.zx.dev" = {
         forceSSL = true;
         useACMEHost = "zx.dev";


### PR DESCRIPTION
## Summary

- Adds `ma.zx.dev` nginx vhost on spore, reverse-proxying to `glyph.note-iwato.ts.net:8095` (Music Assistant web UI)
- WebSocket proxying enabled — MA uses WebSockets for real-time player state updates in the browser
- TLS covered by the existing `*.zx.dev` wildcard cert (no cert changes needed)

Stacked on #528 (enables music-assistant on glyph).

## Test plan

- [ ] Deploy glyph first (`nh os switch .#glyph`) so MA is running on port 8095
- [ ] Deploy spore (`nh os switch .#spore`)
- [ ] `https://ma.zx.dev` loads the Music Assistant UI
- [ ] Real-time player status updates work in the browser (WebSocket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)