### PR TITLE
chore: update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -218,11 +218,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785627969,
-        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
         "type": "github"
       },
       "original": {
@@ -298,11 +298,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1787549117,
-        "narHash": "sha256-pY9P2sb4s/ErYUhK9LMh65wRh1Bkq86IxySMde3YBrU=",
+        "lastModified": 1787633479,
+        "narHash": "sha256-pQfj7SKNNuywU/1Gonwam2GUXnt3Ot8FLuhhZQN9Wns=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "db8d6c667f9e40456b7bdbd9cb10610d6730fea5",
+        "rev": "e37ed690b4f5d4b8577ee2f02472e9b25becca4c",
         "type": "github"
       },
       "original": {
@@ -314,11 +314,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1787549347,
-        "narHash": "sha256-37GHK2fa752l2/GsLtYhtjhxjjeBOZGY0AM49ze98tY=",
+        "lastModified": 1787632596,
+        "narHash": "sha256-fCUKXMFtWfkGHC9XSqSL8GvETC9J9jyuFAXA3kOVL0A=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "a190d1f052d0d428df21637600039dd334de9f09",
+        "rev": "d1d7dfb572bc2279557854cbe56ffbe2a08f47b7",
         "type": "github"
       },
       "original": {
@@ -503,11 +503,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake.lock: Update

Flake lock file updates:

• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a?narHash=sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw%3D' (2026-08-01)
  → 'github:hercules-ci/flake-parts/9d0d87172c374f89da73c1cfe6d81ae62feac1f1?narHash=sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw%3D' (2026-08-24)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/db8d6c667f9e40456b7bdbd9cb10610d6730fea5?narHash=sha256-pY9P2sb4s/ErYUhK9LMh65wRh1Bkq86IxySMde3YBrU%3D' (2026-08-24)
  → 'github:homebrew/homebrew-cask/e37ed690b4f5d4b8577ee2f02472e9b25becca4c?narHash=sha256-pQfj7SKNNuywU/1Gonwam2GUXnt3Ot8FLuhhZQN9Wns%3D' (2026-08-25)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/a190d1f052d0d428df21637600039dd334de9f09?narHash=sha256-37GHK2fa752l2/GsLtYhtjhxjjeBOZGY0AM49ze98tY%3D' (2026-08-24)
  → 'github:homebrew/homebrew-core/d1d7dfb572bc2279557854cbe56ffbe2a08f47b7?narHash=sha256-fCUKXMFtWfkGHC9XSqSL8GvETC9J9jyuFAXA3kOVL0A%3D' (2026-08-25)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/2c423e03bbafcff28bfadc6781a4a8257f205cb5?narHash=sha256-dt4WdcvsA8/RCe%2BVZZwqU0X%2BXMM3wBbGCWA0/sFWzGo%3D' (2026-08-22)
  → 'github:NixOS/nixpkgs/56c02bc00adcf003215cc4bd996d6efaf4cff188?narHash=sha256-9i/VTdusq/%2BNM/tz%2BJ1Re%2BojkMB8MBf0QshnYfzHz30%3D' (2026-08-23)
• Updated input 'systems':
    'path:./flake.systems.nix'
  → 'path:./flake.systems.nix'