### PR TITLE
fix(glyph): fix atticd database connection with PrivateUsers=true

### DIFF
--- a/hosts/glyph/services/attic.nix
+++ b/hosts/glyph/services/attic.nix
@@ -8,7 +8,7 @@
     settings = {
       listen = "[::]:8199";
 
-      database.url = "postgresql:///atticd?host=/run/postgresql";
+      database.url = "postgresql:///atticd?host=/run/postgresql&user=atticd";
 
       storage = {
         type = "local";


### PR DESCRIPTION
## Summary

Fixes atticd crashing on startup after a flake update introduced `PrivateUsers=true` to the atticd systemd unit.

## Root cause

The attic NixOS module added `PrivateUsers=true` in a recent update, which runs the service inside a user namespace. When atticd connects to PostgreSQL via Unix socket without an explicit `user=` in the connection string, libpq calls `getpwuid()` to determine the connecting username. Inside a `PrivateUsers` namespace, the dynamic user's UID isn't resolvable through the systemd NSS module (the userdb socket isn't bridged into the namespace), so `getpwuid()` returns null. libpq then falls through to check `USER`/`LOGNAME` env vars — neither of which is set in the service environment — and finally falls back to the hardcoded default `"anonymous"`. PostgreSQL rejects the connection with `role "anonymous" does not exist`.

## Fix

Add `user=atticd` as an explicit query parameter to the database URL. This bypasses `getpwuid()` entirely.

```
# before
postgresql:///atticd?host=/run/postgresql

# after
postgresql:///atticd?host=/run/postgresql&user=atticd
```

Note: the `user@host` URL form (`postgresql://atticd@/atticd?...`) was attempted first but rejected by the Rust PostgreSQL driver — the query parameter form is the correct approach for Unix socket connections.

## Stacked on

- #532 (Documents Samba share + WebDAV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)