### PR TITLE
fix: pin golink to last go 1.26.5-compatible commit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,16 +262,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1787241322,
-        "narHash": "sha256-RUS9EtnG0VwRzOV0a0f8vC1nxpjSRONSHdLaQ2Z5aUE=",
+        "lastModified": 1787148908,
+        "narHash": "sha256-1jJGOXOkQtfL7h8cKWNS4btJGMQjdzSiUPLdosZbajM=",
         "owner": "tailscale",
         "repo": "golink",
-        "rev": "3f9300f2b03f29f1a2eb704ff419d849f47aabf4",
+        "rev": "52e1fd108b6362c7269fc834f854146b21a3bfc7",
         "type": "github"
       },
       "original": {
         "owner": "tailscale",
         "repo": "golink",
+        "rev": "52e1fd108b6362c7269fc834f854146b21a3bfc7",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,8 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     golink = {
-      url = "github:tailscale/golink";
+      # Pinned to last commit compatible with go 1.26.5 (nixpkgs); next commit bumped to 1.26.6
+      url = "github:tailscale/golink/52e1fd108b6362c7269fc834f854146b21a3bfc7";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.systems.follows = "systems";
     };

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
     };
     golink = {
       # Pinned to last commit compatible with go 1.26.5 (nixpkgs); next commit bumped to 1.26.6
+      # Unpin when nixpkgs reaches go 1.26.6 — tracked in https://github.com/stackptr/rc/issues/536
       url = "github:tailscale/golink/52e1fd108b6362c7269fc834f854146b21a3bfc7";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.systems.follows = "systems";


### PR DESCRIPTION
## Summary

- golink's `main` branch bumped `go.mod` minimum requirement to go 1.26.6
- nixpkgs currently ships go 1.26.5, so spore builds were failing with `go.mod requires go >= 1.26.6 (running go 1.26.5)`
- Pins the golink flake input to commit `52e1fd1`, the last commit that only requires go 1.26.5

## Verify

After merging, spore should build cleanly:
- `nixos-rebuild switch --flake .#spore --target-host root@spore --build-host localhost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)